### PR TITLE
Use `rsync` instead of `cp` when installing plugins.

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -101,10 +101,7 @@ bundle-install () {
         if [[ $name != *.theme ]]; then
             echo Installing $name
             mkdir -p "$ANTIGEN_BUNDLE_DIR/$name"
-            pushd "$clone_dir/$loc" > /dev/null
-            ls | grep -Fv '.git' \
-                | xargs cp -rt "$ANTIGEN_BUNDLE_DIR/$name"
-            popd > /dev/null
+            rsync --archive --exclude=.git "$clone_dir/$loc/" "$ANTIGEN_BUNDLE_DIR/$name"
         else
             mkdir -p "$ANTIGEN_BUNDLE_DIR/$name"
             cp "$clone_dir/$loc" "$ANTIGEN_BUNDLE_DIR/$name"


### PR DESCRIPTION
Rsync has a built in `--exclude` option so we can exclude the `.git` directory.

Antigen now also works on OS X and other BSD based systems that don't have a GNU version of `cp`. This also allows us to remove the `pushd` and `popd` lines because we are no longer using changing directory to use `ls`.

Thanks @jasoncodes for answering why it wasn't working on OS X and pointing me in the right direction to get it working!
