### PR TITLE
Add "repos/" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tests/.zcompdump
 
 # Test failure reports
 tests/*.t.err
+
+# Repos, in cases when autogen is included as a submodule
+repos/


### PR DESCRIPTION
First of all, thank you for this project, it is really appreciated! :)

I just want to have `repos/` in `.gitignore` because I use 'antigen' as a submodule in my 'dotfiles' repo with `.antigen` path.
