### PR TITLE
Remove "already on branch xxx" on every shell startup

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -197,7 +197,11 @@ antigen-update () {
 
     # If its a specific branch that we want, checkout that branch.
     if [[ $url == *\|* ]]; then
-        Git checkout "${url#*|}"
+        local current_branch=${$(Git symbolic-ref HEAD)##refs/heads/}
+        local requested_branch="${url#*|}"
+        # Only do the checkout when we are not already on the branch
+        [[ $requested_branch != $current_branch ]] &&
+        Git checkout $requested_branch
     fi
 
     if ! [[ -z $old_rev || $old_rev == $new_rev ]]; then

--- a/tests/branch-bundle.t
+++ b/tests/branch-bundle.t
@@ -25,6 +25,10 @@ Load plugin from b1.
   $ hehe
   hehe from b1
 
+Does not say 'Already on b1' on each session startup.
+
+  $ antigen-bundle $PLUGIN_DIR --branch=b1
+
 Load plugin from master.
 
   $ antigen-bundle $PLUGIN_DIR


### PR DESCRIPTION
If you have a

```
antigen-bundle some/repo --branch=something
```

it will tell you on each shell startup (except for the first one where the repo is initialized) `already on branch 'something'`. This pull request includes a fix + a test.
