### PR TITLE
improve startup speed by only calling `compinit -i` once

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -338,6 +338,7 @@ antigen-apply () {
     # TODO: Only load completions if there are any changes to the bundle
     # repositories.
     compinit -i
+    compdef _antigen antigen
 }
 
 antigen-list () {
@@ -592,11 +593,6 @@ antigen () {
 
     # Load the compinit module.
     autoload -U compinit
-
-    # Without the following, `compdef` function is not defined.
-    compinit -i
-
-    compdef _antigen antigen
 }
 
 # Same as `export $1=$2`, but will only happen if the name specified by `$1` is


### PR DESCRIPTION
I don't see the need for calling compinit -i in env-setup just so we can setup compdef for the antigen command, compinit -i is called again in antigen-apply and the user is not likely to be interacting with their shell before the call to antigen-apply has been made.

This change gave me a 58% speedup in startup time (from 1.7s to 0.98s).

Refs #28
