### PR TITLE
Simplify loading logic

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -224,7 +224,7 @@ antigen-revert () {
     fi
     local type="$3"
     local cloned="$4"
-    local plugin=$(echo $location|cut -d '/' -f 2)
+    local plugin=$(basename $location)
 
     case $type in
         (theme) source "$location";;


### PR DESCRIPTION
The old code loading used to depend on null_glob and extended_glob.  I
have simplified it to use regular globs, and `grep -c`.  The
`.plugin.zsh` logic was redundant, because plugins get pulled in anyway
(by *.zsh).

**NOTE**: I accidentally included comments from @wrboyce's #37 in here, but it should still merge fine.
