### PR TITLE
Making _ANTIGEN_INSTALL_DIR use absolute path.

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -5,7 +5,7 @@
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
 # FIXME: Is not kept local by zsh!
 local _ANTIGEN_BUNDLE_RECORD=""
-local _ANTIGEN_INSTALL_DIR="$(dirname $0)"
+local _ANTIGEN_INSTALL_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # Syntaxes
 #   antigen-bundle <url> [<loc>=/]


### PR DESCRIPTION
This will prevent errors if someone sources antigen using a relative path.
