### PR TITLE
Fixing grep compatibility on older systems

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -621,7 +621,7 @@ antigen () {
         fi
 
         # The specification for this argument, used for validations.
-        local arg_line="$(echo "$keyword_args" | grep "^$name:\??\?" | head -n1)"
+        local arg_line="$(echo "$keyword_args" | egrep "^$name:?\??" | head -n1)"
 
         # Validate argument and value.
         if [[ -z $arg_line ]]; then


### PR DESCRIPTION
Unfortunately, older versions of grep don't have `-m` or `-q`.
Wherever `-q` was being used silence output, I changed it to redirect to `/dev/null`.
Wherever `-m1` was used to stop searching after the first match, I replaced it with `-l`.
Wherever `-m1` was used to only take the first line of output, I piped it into `head -n1`.

This fixed compatibility for me with grep on Solaris 9.
