### PR TITLE
Let antigen-selfupdate works when in submodule

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -316,10 +316,15 @@ antigen-revert () {
 # "what's new" message.
 antigen-selfupdate () {
     ( cd $_ANTIGEN_INSTALL_DIR
-        if [[ ! -d .git ]]; then
+        if [[ ! ( -d .git || -f .git ) ]]; then
             echo "Your copy of antigen doesn't appear to be a git clone. " \
                 "The 'selfupdate' command cannot work in this case."
             return 1
+        fi
+        local head="$(git rev-parse --abbrev-ref HEAD)"
+        if [[ $head == "HEAD" ]]; then
+            # If current head is detached HEAD, checkout to master branch.
+            git checkout master
         fi
         git pull
     )


### PR DESCRIPTION
When antigen is in submodule (ex: antigen is a submodule of dotfiles repo), the `.git` will be a regular file instead of directory. In this case, `antigen-selfupdate` refuses to update itself because there is no `.git` directory. This patch changes the condition to `-d .git || -f .git` so that `antigen-selfupdate` can work when antigen is a submodule. Also, `git checkout master` is added because submodule will detach from master branch.
