### PR TITLE
Add test cases for antigen-selfupdate

### DIFF
--- a/tests/selfupdate.t
+++ b/tests/selfupdate.t
@@ -1,0 +1,73 @@
+Set environment variables for this test case
+
+  $ export TEST_DIR=$PWD
+  $ export TEST_HOST=$TEST_DIR/host
+  $ export TEST_NORMAL=$TEST_DIR/client
+  $ export TEST_SUBMODULE=$TEST_DIR/submodule
+
+Create fake host repository
+
+  $ mkdir -p $TEST_HOST
+  $ cd $TEST_HOST
+  $ git init
+  Initialized empty Git repository in * (glob)
+  $ echo 1 > ver
+  $ git add ver
+  $ git commit -m "1"
+  [master (root-commit) ???????] 1 (glob)
+   1 file changed, 1 insertion(+)
+   create mode 100644 ver
+
+Create a normal repository cloning from host
+
+  $ git clone $TEST_HOST $TEST_NORMAL
+  Cloning into * (glob)
+  done.
+
+Create a submodule repository cloning from host
+
+  $ mkdir -p $TEST_SUBMODULE
+  $ cd $TEST_SUBMODULE
+  $ git init
+  Initialized empty Git repository in * (glob)
+  $ git submodule add $TEST_HOST antigen
+  Cloning into 'antigen'...
+  done.
+  $ git commit -m "1"
+  [master (root-commit) ???????] 1 (glob)
+   2 files changed, 4 insertions(+)
+   create mode 100644 .gitmodules
+   create mode 160000 antigen
+
+Update host repository
+
+  $ cd $TEST_HOST
+  $ echo 2 > ver
+  $ git add ver
+  $ git commit -m "2"
+  [master ???????] 2 (glob)
+   1 file changed, 1 insertion(+), 1 deletion(-)
+
+Use selfupdate from normal repository
+
+  $ _ANTIGEN_INSTALL_DIR=$TEST_NORMAL antigen-selfupdate
+  From * (glob)
+     ???????..???????  master     -> origin/master (glob)
+  Updating ???????..??????? (glob)
+  Fast-forward
+   ver | 2 +-
+   1 file changed, 1 insertion(+), 1 deletion(-)
+  $ _ANTIGEN_INSTALL_DIR=$TEST_NORMAL antigen-selfupdate
+  Already up-to-date.
+
+Use selfupdate from submodule repository
+
+  $ _ANTIGEN_INSTALL_DIR=$TEST_SUBMODULE/antigen antigen-selfupdate
+  From * (glob)
+     ???????..???????  master     -> origin/master (glob)
+  Updating ???????..??????? (glob)
+  Fast-forward
+   ver | 2 +-
+   1 file changed, 1 insertion(+), 1 deletion(-)
+  $ _ANTIGEN_INSTALL_DIR=$TEST_SUBMODULE/antigen antigen-selfupdate
+  Already up-to-date.


### PR DESCRIPTION
This is the test cases for #65. The test procedure is listed as following:
1. Create a repository as host
2. Clone host repository as normal and submodule repository
3. Update host repository
4. use `antigen-selfupdate` to update normal and submodule repository

I am not sure if this is okay to test `antigen-selfupdate`. Please help to review it, thanks.
