### PR TITLE
Fix fpath for bundle zsh-users/zsh-completions

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -302,7 +302,15 @@ antigen-revert () {
             # `*.sh` files instead.
             for script ($location/*.sh(N)) source "$script"
 
+        elif echo "$location" | grep -l 'zsh-users-SLASH-zsh-completions\.git' &> /dev/null; then
+            # If the location indicates zsh-users/zsh-completions
+            # then add 'src'
+            location+='src'
+
         fi
+
+        # Substitute // with /
+        location=`echo "$location" | sed -e 's.//./.g'`
 
         # Add to $fpath, for completion(s).
         fpath=($location $fpath)

--- a/tests/bundle-zsh-completions.t
+++ b/tests/bundle-zsh-completions.t
@@ -1,0 +1,24 @@
+Set environment variables for this test case
+
+  $ export FPATH_BACKUP=$FPATH
+  $ unset FPATH
+
+Add bundle for zsh-users/zsh-completions.
+
+  $ echo "zsh-users/zsh-completions" | antigen-bundles
+  Cloning into '.+?'\.\.\. (re)
+
+Check $FPATH variable.
+
+  $ echo $FPATH | perl -pe 's/ /\n/g'
+  *https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-completions.git/src (glob)
+
+clean it all up.
+
+  $ export _ANTIGEN_BUNDLE_RECORD=""
+  $ antigen-cleanup --force &> /dev/null
+
+Set environment variables for this test case
+
+  $ export FPATH=$FPATH_BACKUP
+  $ unset FPATH_BACKUP=""


### PR DESCRIPTION
Hello. I'm new to antigen. :)

I want to use [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions), but antigen can't set $FPATH variable properly.
So i fix this problem and make unit test.

Please review and merge my code.

Thanks.
