### PR TITLE
Ignore the repos folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tests/.zcompdump
 
 # Test failure reports
 tests/*.t.err
+
+# Ignore the repos folder
+repos/


### PR DESCRIPTION
I use the `.antigen` folder as the _clone_ folder in a submodule which puts all the cloned repositories under the Git controlled folder. this PR ignores the **repos/** folder so it does not show as dirty in `git status`
