### PR TITLE
Ignore revert-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tests/*.t.err
 
 # Ignore the repos folder
 repos/
+
+# Ignore the revert-info file
+revert-info


### PR DESCRIPTION
It looks like antigen update spit out an untracked file called `revert-info`, this keeps it out of git.
