### PR TITLE
Permit non github urls

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -89,6 +89,8 @@ antigen-bundle () {
     # Expand short github url syntax: `username/reponame`.
     if [[ $url != git://* &&
             $url != https://* &&
+            $url != http://* &&
+            $url != ssh://* &&
             $url != /* &&
             $url != git@github.com:*/*
             ]]; then


### PR DESCRIPTION
Really wanted to use antigen for a company specific repo that was served over the local network via http and ssh. Unfortunately antigen was consistently rewriting the URLs to include https://github.com. Expanding the list of acceptable looking URLs fixes this issue.

Antigen is so good it shouldn't be restricted.

Don't really know a good way to handle the user@host type thing apart
from just looking for an @, which seems overly broad.
