### PR TITLE
Make no-local-clone sourcing consistent with clone sourcing

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -263,7 +263,7 @@ antigen-revert () {
     if $make_local_clone; then
         location="$(-antigen-get-clone-dir "$url")/$loc"
     else
-        location="$url"
+        location="$url/$loc"
     fi
 
     if [[ $btype == theme ]]; then


### PR DESCRIPTION
As it stands, --no-local-clone option makes antigen ignore the location argument.  This patch fixes it and makes it work the same as with a regular local clone.
