### PR TITLE
Fix "selfupdate" and Use git itself to check if ANTIGEN_INSTALL_DIR is a git repository.

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -314,7 +314,8 @@ antigen-revert () {
 # "what's new" message.
 antigen-selfupdate () {
     ( cd $ANTIGEN_INSTALL_DIR
-        if [[ ! ( -d .git || -f .git ) ]]; then
+        git rev-parse &> /dev/null
+        if [[ $? -ne 0 ]]; then
             echo "Your copy of antigen doesn't appear to be a git clone. " \
                 "The 'selfupdate' command cannot work in this case."
             return 1


### PR DESCRIPTION
```
»  zsh --version                                                          
zsh 5.0.5 (i686-pc-linux-gnu)
```
- I installed antigen using `git clone`. When running the `antigen selfupdate` command, it gives this error

```
Your copy of antigen doesn't appear to be a git clone. 
The 'selfupdate' command cannot work in this case.
```

As `ANTIGEN_INSTALL_DIR` will be used later by `antigen-selfupdate`, it should be exported. Or `cd $ANTIGEN_INSTALL_DIR` within

```
antigen-selfupdate () {
    ( cd $ANTIGEN_INSTALL_DIR
      # ...
    )
} 
```

will navigate to the home directory.
- I think it's better to use git itself to check if ANTIGEN_INSTALL_DIR is a git repository. This can be done via

```
git rev-parse &> /dev/null
if [[ $? -ne 0 ]]; then
   echo "Your copy of antigen doesn't appear to be a git clone. " \
           "The 'selfupdate' command cannot work in this case."
   return 1
fi
```
