### PR TITLE
Fix "selfupdate" and Use git itself to check if ANTIGEN_INSTALL_DIR is a git repository.

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -9,7 +9,7 @@
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
 # FIXME: Is not kept local by zsh!
 local _ANTIGEN_BUNDLE_RECORD=""
-local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Used to defer compinit/compdef
 typeset -a __deferred_compdefs
@@ -147,7 +147,7 @@ antigen-revert () {
         echo "Reverted to state before running -update on $(
                 cat $ADOTDIR/revert-info | sed -n 1p)."
 
-    else 
+    else
         echo 'No revert information available. Cannot revert.' >&2
     fi
 
@@ -313,7 +313,7 @@ antigen-revert () {
 # TODO: Once update is finished, show a summary of the new commits, as a kind of
 # "what's new" message.
 antigen-selfupdate () {
-    ( cd $_ANTIGEN_INSTALL_DIR
+    ( cd $ANTIGEN_INSTALL_DIR
         if [[ ! ( -d .git || -f .git ) ]]; then
             echo "Your copy of antigen doesn't appear to be a git clone. " \
                 "The 'selfupdate' command cannot work in this case."

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -314,7 +314,8 @@ antigen-revert () {
 # "what's new" message.
 antigen-selfupdate () {
     ( cd $ANTIGEN_INSTALL_DIR
-        if [[ ! ( -d .git || -f .git ) ]]; then
+        git rev-parse &> /dev/null
+        if [[ $? -ne 0 ]]; then
             echo "Your copy of antigen doesn't appear to be a git clone. " \
                 "The 'selfupdate' command cannot work in this case."
             return 1

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -9,7 +9,7 @@
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
 # FIXME: Is not kept local by zsh!
 local _ANTIGEN_BUNDLE_RECORD=""
-ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+_ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Used to defer compinit/compdef
 typeset -a __deferred_compdefs
@@ -313,7 +313,7 @@ antigen-revert () {
 # TODO: Once update is finished, show a summary of the new commits, as a kind of
 # "what's new" message.
 antigen-selfupdate () {
-    ( cd $ANTIGEN_INSTALL_DIR
+    ( cd $_ANTIGEN_INSTALL_DIR
         git rev-parse &> /dev/null
         if [[ $? -ne 0 ]]; then
             echo "Your copy of antigen doesn't appear to be a git clone. " \


### PR DESCRIPTION
```
»  zsh --version                                                          
zsh 5.0.5 (i686-pc-linux-gnu)
```
* I installed antigen using ```git clone```. When running the ```antigen selfupdate``` command, it gives this error
```
Your copy of antigen doesn't appear to be a git clone. 
The 'selfupdate' command cannot work in this case.
```
As ```_ANTIGEN_INSTALL_DIR``` will be used later by ```antigen-selfupdate```, it should be exported. Or ```cd $_ANTIGEN_INSTALL_DIR``` within
```
antigen-selfupdate () {
    ( cd $_ANTIGEN_INSTALL_DIR
      # ...
    )
} 
```
will navigate to the home directory.

* I think it's better to use git itself to check if _ANTIGEN_INSTALL_DIR is a git repository. This can be done via
```
git rev-parse &> /dev/null
if [[ $? -ne 0 ]]; then
   echo "Your copy of antigen doesn't appear to be a git clone. " \
           "The 'selfupdate' command cannot work in this case."
   return 1
fi
```