### PR TITLE
use COMPDUMPFILE variable as completion dump file location

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -441,10 +441,10 @@ antigen-apply () {
     # Load the compinit module. This will readefine the `compdef` function to
     # the one that actually initializes completions.
     autoload -U compinit
-    if [[ -z $COMPDUMPFILE ]]; then
+    if [[ -z $ANTIGEN_COMPDUMPFILE ]]; then
         compinit -i
     else
-        compinit -i -d $COMPDUMPFILE
+        compinit -i -d $ANTIGEN_COMPDUMPFILE
     fi
 
     # Apply all `compinit`s that have been deferred.

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -441,7 +441,11 @@ antigen-apply () {
     # Load the compinit module. This will readefine the `compdef` function to
     # the one that actually initializes completions.
     autoload -U compinit
-    compinit -i
+    if [[ -z $COMPDUMPFILE ]]; then
+        compinit -i
+    else
+        compinit -i -d $COMPDUMPFILE
+    fi
 
     # Apply all `compinit`s that have been deferred.
     eval "$(for cdef in $__deferred_compdefs; do


### PR DESCRIPTION
I have slightly changed `antigen-apply()` function to use `$COMPDUMPFILE` variable as completion dump file location.

I have tested it, I think it works well. Is there any problem that this code could cause?