### PR TITLE
Add make install task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-.PHONY: itests tests
+.PHONY: itests tests install all
 
 PYENV ?= . .pyenv/bin/activate &&
 TESTS ?= tests
+PREFIX ?= /usr/local
 
 itests:
 	${MAKE} tests CRAM_OPTS=-i
 
 tests:
 	${PYENV} ZDOTDIR="${PWD}/tests" cram ${CRAM_OPTS} --shell=zsh ${TESTS}
+
+install:
+	mkdir -p ${PREFIX}/share && cp ${PWD}/antigen.zsh ${PREFIX}/share/antigen.zsh
+
+clean:
+	rm -f ${PREFIX}/share/antigen.zsh
+
+all: clean tests install

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ tests:
 	${PYENV} ZDOTDIR="${PWD}/tests" cram ${CRAM_OPTS} --shell=zsh ${TESTS}
 
 install:
-	mkdir -p ${PREFIX}/share && cp ${PWD}/antigen.zsh ${PREFIX}/share/antigen.zsh
+	mkdir -p ${PREFIX}/share && cp ./antigen.zsh ${PREFIX}/share/antigen.zsh
 
 clean:
 	rm -f ${PREFIX}/share/antigen.zsh
 
-all: clean tests install
+all: clean install


### PR DESCRIPTION
This is the first step to [adding antigen to homebrew](https://github.com/tubbo/homebrew/compare/add-homer), and possibly other package managers as well. Makes it a lot easier to install the script and keep it up to date. `make install` will now copy antigen.zsh to /usr/local/share by default.