### PR TITLE
Handle compdef file locations: don't source add to $fpath

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -266,7 +266,12 @@ antigen-revert () {
     fi
 
     if [[ -f "$location" ]]; then
-        source "$location"
+        if [[ ${$(<$location)[1]} == "#compdef" ]]; then
+            # Add directory to $fpath, for completion(s).
+            fpath=(${location:h} $fpath)
+        else
+            source "$location"
+        fi
 
     else
 


### PR DESCRIPTION
This allows to use completions from somewhere, e.g.

    antigen bundle blueyed/hub --loc=etc/_hub --branch=improve-zsh-completion

Without this patch, an error is thrown:

    % antigen bundle blueyed/hub --loc=etc/hub.zsh_completion --branch=improve-zsh-completion
    _arguments:comparguments:312: can only be called from completion function

This then still needs a call to `compinit`, but that's meant to happen through `antigen apply`?!