### PR TITLE
Fix download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ sample, if you will.</p>
 
 <p>Get and load antigen.</p>
 
-<pre><code>curl https://raw.github.com/zsh-users/antigen/master/antigen.zsh &gt; antigen.zsh
+<pre><code>curl -L https://raw.githubusercontent.com/zsh-users/antigen/master/antigen.zsh &gt; antigen.zsh
 source antigen.zsh
 </code></pre>
 


### PR DESCRIPTION
The website's download link uses an old "raw" Github link which no longer works. Replaced it with the URL found in the README.