### PR TITLE
Include default ZSH_CACHE_DIR when using oh-my-zsh

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -396,6 +396,9 @@ antigen-use () {
     if [[ -z "$ZSH" ]]; then
         export ZSH="$(-antigen-get-clone-dir "$ANTIGEN_DEFAULT_REPO_URL")"
     fi
+    if [[ -z "$ZSH_CACHE_DIR" ]]; then
+        export ZSH_CACHE_DIR="$ZSH/cache/"
+    fi
     antigen-bundle --loc=lib
 }
 


### PR DESCRIPTION
Some oh-my-zsh scripts expect this environment variable to be set, e.g.
https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/last-working-dir/last-working-dir.plugin.zsh#L7

oh-my-zsh also initializes this variable on startup:
https://github.com/robbyrussell/oh-my-zsh/blob/master/oh-my-zsh.sh#L19