### PR TITLE
Remove refrences to sharat87/autoenv

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,10 +100,9 @@ utilities as small scripts all the time. Antigen is compatible with all of them.
 The plugins and scripts don't need any special handling to be compatible with
 antigen.</p>
 
-<p>Another example, <a href="https://github.com/kennethreitz/autoenv">kennethreitz's autoenv</a> (or <a href="https://github.com/sharat87/autoenv">my fork</a> of
-it). Just a bundle command away.</p>
+<p>Another example, <a href="https://github.com/kennethreitz/autoenv">kennethreitz's autoenv</a>. Just a bundle command away.</p>
 
-<pre><code>antigen bundle sharat87/autoenv
+<pre><code>antigen bundle kennethreitz/autoenv
 </code></pre>
 
 <p>And boom! you have all the autoenv goodness. Just remember how you used to do


### PR DESCRIPTION
It could be misleading to those wanting to use autoenv if they just decide to pull down your fork without too much examination and don't check to see that your fork has already been ~~merged~~ closed (I can't read!) ([kennethreitz/autoenv#39](https://github.com/kennethreitz/autoenv/pull/39)) and that much more work has been put into the main repo.