### PR TITLE
Add feature to list all bundle absolute paths

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -329,8 +329,8 @@ Insider detail: The information for reverting is stored in
 Use this command to list out the currently *loaded* plugins. Keep in mind that
 this includes any bundles installed on-the-fly.
 
-Takes no arguments. Gives out four entries per line of output, denoting the
-following fields of each bundle.
+Gives out four entries per line of output, denoting the following fields of
+each bundle.
 
     <repo-url> <loc> <btype> <has-local-clone?>
 
@@ -339,6 +339,8 @@ The `btype` field is an internal detail, that specifies if the bundle is a
 
 The final field is `true` or `false` reflecting whether there is a local clone
 for this bundle.
+
+If the `--path` argument is given, lists all bundle absolute paths.
 
 ### antigen cleanup
 

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -457,6 +457,13 @@ antigen-list () {
     if [[ -z "$_ANTIGEN_BUNDLE_RECORD" ]]; then
         echo "You don't have any bundles." >&2
         return 1
+    # List all currently installed bundle absolute paths.
+    elif [[ -n "$1" && "$1" == "--path" ]]; then
+        -antigen-echo-record |
+            awk '$4 == "true" {print $1}' |
+            while read line; do
+                -antigen-get-clone-dir "$line"
+            done | sort -u
     else
         -antigen-echo-record | sort -u
     fi

--- a/tests/list.t
+++ b/tests/list.t
@@ -22,3 +22,9 @@ Add another bundle.
   $ antigen-list
   */test-plugin / plugin true (glob)
   */test-plugin2 / plugin true (glob)
+
+List all bundle paths.
+
+  $ antigen-list --path
+  *t-SLASH-test-plugin (glob)
+  *t-SLASH-test-plugin2 (glob)


### PR DESCRIPTION
Sometimes I want to get my local bundle paths, for example:

* tweaking some codes
* [peco style](https://github.com/peco/peco) directory moving

So I add this feature. I think useful feature for some people.