### PR TITLE
[WIP] Cache for faster start up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tests/*.t.err
 # following would be shown as untracked.
 repos/
 revert-info
+
+# Cache directory for ext/zcache
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ cache:
   directories:
     - $HOME/zsh
     - $HOME/.zsh-builds
+    - $HOME/.antigen
 
 env:
   global:
+    - ANTIGEN=$TRAVIS_BUILD_DIR
     - ZSH_REMOTE_URL=https://github.com/zsh-users/zsh.git
     - BUILDS_PATH=$HOME/.zsh-builds
     - ZSH_SOURCE=$HOME/zsh
@@ -22,6 +24,13 @@ env:
     - ZSH_VERSION=zsh-5.0.0
     - ZSH_VERSION=zsh-4.3.17
     - ZSH_VERSION=zsh-4.3.5
+
+install:
+  # Install python requirements.
+  - "pip install cram==0.6"
+
+  # Install zsh versions from source.
+  - "./tests/build-zsh.sh $ZSH_VERSION $BUILDS_PATH $ZSH_SOURCE"
 
 before_script:
   # Show the git version being used to test.
@@ -34,12 +43,9 @@ before_script:
   # Show zsh version being deployed.
   - "$BUILDS_PATH/$ZSH_VERSION/zsh --version"
 
-install:
-  # Install python requirements.
-  - "pip install cram==0.6"
-
-  # Install zsh versions from source.
-  - "./tests/build-zsh.sh $ZSH_VERSION $BUILDS_PATH $ZSH_SOURCE"
-
 # Run the tests.
-script: "make tests PYENV= SHELL=$BUILDS_PATH/$ZSH_VERSION/zsh"
+script:
+  - "make tests PYENV= SHELL=$BUILDS_PATH/$ZSH_VERSION/zsh"
+  - "make stats _ANTIGEN_CACHE_ENABLED=false _ANTIGEN_INIT_ENABLED=false SHELL=$BUILDS_PATH/$ZSH_VERSION/zsh"
+  - "make stats _ANTIGEN_CACHE_ENABLED=true _ANTIGEN_INIT_ENABLED=false SHELL=$BUILDS_PATH/$ZSH_VERSION/zsh"
+  - "make stats _ANTIGEN_CACHE_ENABLED=true _ANTIGEN_INIT_ENABLED=true SHELL=$BUILDS_PATH/$ZSH_VERSION/zsh"

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,22 @@ PYENV ?= . .pyenv/bin/activate &&
 TESTS ?= tests
 PREFIX ?= /usr/local
 SHELL ?= zsh
+PROJECT ?= .
 
 itests:
 	${MAKE} tests CRAM_OPTS=-i
 
 tests:
-	${PYENV} ZDOTDIR="${PWD}/tests" cram ${CRAM_OPTS} --shell=${SHELL} ${TESTS}
+	${PYENV} ZDOTDIR="${ANTIGEN}/tests" cram ${CRAM_OPTS} --shell=${SHELL} ${TESTS}
+
+stats:
+	cp ${PROJECT}/tests/.zshrc ${HOME}/.zshrc
+	for i in $$(seq 1 10); do /usr/bin/time -f "#$$i \t%es real \t%Us user \t%Ss system \t%x status" "${SHELL}" -ic exit; done
 
 install:
-	mkdir -p ${PREFIX}/share && cp ./antigen.zsh ${PREFIX}/share/antigen.zsh
+	mkdir -p ${PREFIX}/share && cp ${PROJECT}/antigen.zsh ${PROJECT}/share/antigen.zsh
 
 clean:
-	rm -f ${PREFIX}/share/antigen.zsh
+	rm -f ${PROJECT}/share/antigen.zsh
 
 all: clean install

--- a/ext/zcache.zsh
+++ b/ext/zcache.zsh
@@ -1,0 +1,276 @@
+export _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$_ANTIGEN_INSTALL_DIR/.cache}"
+export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
+export _ZCACHE_META_PATH="$_ZCACHE_PATH/.zcache-meta"
+export _ZCACHE_EXTENSION_LOADED=true
+local -a _ZCACHE_BUNDLES
+
+# Clears $0 and ${0} references from cached sources.
+#
+# This is needed otherwise plugins trying to source from a different path
+# will break as those are now located at $_ZCACHE_PAYLOAD_PATH
+#
+# Usage
+#   -zcache-process-source "/path/to/source"
+#
+# Returns
+#   Returns the cached sources without $0 and ${0} references
+-zcache-process-source () {
+    cat "$1"     \
+        | sed $'/\${0/i\\\n__ZCACHE_FILE_PATH=\''$1$'\'\n' \
+        | sed -e "s/\${0/\${__ZCACHE_FILE_PATH/" \
+        | sed $'/\$0/i\\\n__ZCACHE_FILE_PATH=\''$1$'\'\n' \
+        | sed -e "s/\$0/\$__ZCACHE_FILE_PATH/"
+}
+
+# Generates cache from listed bundles.
+#
+# Iterates over _ZCACHE_BUNDLES and install them (if needed) then join all needed
+# sources into one, this is done through -antigen-load-list.
+# Result is stored in _ZCACHE_PAYLOAD_PATH. Loaded bundles and metadata is stored
+# in _ZCACHE_META_PATH.
+#
+# _ANTIGEN_BUNDLE_RECORD and fpath is stored in cache.
+#
+# Usage
+#   -zcache-generate-cache
+#   Uses _ZCACHE_BUNDLES (array)
+#
+# Returns
+#   Nothing. Generates _ZCACHE_META_PATH and _ZCACHE_PAYLOAD_PATH
+-zcache-generate-cache () {
+    local -a _extensions_paths
+    local -a _bundles_meta
+    local _payload=''
+
+    _payload+="#-- START ZCACHE GENERATED FILE\NL"
+    _payload+="#-- GENERATED: $(date)\NL"
+    for bundle in $_ZCACHE_BUNDLES; do
+        # -antigen-load-list "$url" "$loc" "$make_local_clone"
+        eval "$(-antigen-parse-bundle ${=bundle})"
+        _bundles_meta+=("$url $loc $btype $make_local_clone $branch")
+        # url=$(-antigen-get-clone-dir "$url")
+        -antigen-load-list "$url" "$loc" "$make_local_clone" | while read line; do
+            if [[ -f "$line" ]]; then
+                _payload+="#-- SOURCE: $line\NL"
+                _payload+=$(-zcache-process-source "$line")
+                _payload+="\NL;#-- END SOURCE\NL"
+            elif [[ -d "$line" ]]; then
+                _extensions_paths+=("$line")
+            fi
+        done
+    done
+    _payload+="fpath+=(${(j: :)_extensions_paths});\NL"
+    _payload+="unset __ZCACHE_FILE_PATH\NL"
+    # \NL (\n) prefix is for backward compatibility
+    _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\"\NL"
+    _payload+="export _ZCACHE_CACHE_LOADED=true\NL"
+    _payload+="#-- END ZCACHE GENERATED FILE\NL"
+
+    echo -E $_payload | sed 's/\\NL/\n/g' >>! $_ZCACHE_PAYLOAD_PATH
+    echo "${(j:\n:)_bundles_meta}" >>! $_ZCACHE_META_PATH
+}
+
+# Generic hook function for various antigen-* commands.
+#
+# The function is used to defer the bundling performed by commands such as
+# bundle, theme and init. This way we can record all the bundled plugins and
+# install/source/cache in one single step.
+#
+# Usage
+#   -zcache-antigen-hook <arguments>
+#
+# Returns
+#   Nothing. Updates _ZACHE_BUNDLES array.
+-zcache-antigen-hook () {
+    local cmd="$1"
+
+    case "$cmd" in
+        use)
+            antigen-use "$2"
+            ;;
+        init)
+            antigen-init "$2"
+            ;;
+        theme)
+            antigen-theme "$2" "$3" "$4"
+            ;;
+        bundle)
+            antigen-bundle "$2" "$3" "$4"
+            ;;
+        apply)
+            zcache-done
+            ;;
+        *)
+            if functions "antigen-$cmd" > /dev/null; then
+                "antigen-$cmd" "$@"
+            else
+                # TODO Remove on 2.x
+                ! zcache-cache-exists && -zcache-antigen-bundle "${=@}"
+                _ZCACHE_BUNDLES+=("$*")
+            fi
+        ;;
+    esac
+}
+
+# Unhook antigen functions to be able to call antigen commands normally.
+#
+# After generating and loading of cache there is no need for defered command
+# calls, so we are leaving antigen as it was before zcache was loaded.
+#
+# Afected functions are antigen, antigen-bundle and antigen-apply.
+#
+# See -zcache-hook-antigen
+#
+# Usage
+#   -zcache-unhook-antigen
+#
+# Returns
+#   Nothing
+-zcache-unhook-antigen () {
+    for function in antigen antigen-bundle antigen-apply; do
+        eval "function $(functions -- -zcache-$function | sed 's/-zcache-//')"
+    done
+}
+
+# Hooks various antigen functions to be able to defer command execution.
+#
+# To be able to record and cache multiple bundles when antigen runs we are
+# hooking into multiple antigen commands, either deferring it's execution
+# or dropping it.
+#
+# Afected functions are antigen, antigen-bundle and antigen-apply.
+#
+# See -zcache-unhook-antigen
+#
+# Usage
+#   -zcache-hook-antigen
+#
+# Returns
+#   Nothing
+-zcache-hook-antigen () {
+    for function in antigen antigen-bundle antigen-apply; do
+        eval "function -zcache-$(functions -- $function)"
+        $function () { -zcache-antigen-hook "$@" }
+    done
+
+    eval "function -zcache-$(functions -- antigen-update)"
+    antigen-update () {
+        -zcache-antigen-update "$@"
+        antigen-cache-reset
+    }
+}
+
+# Starts zcache execution.
+#
+# Hooks into various antigen commands to be able to record and cache multiple
+# bundles, themes and plugins.
+#
+# Usage
+#   zcache-start
+#
+# Returns
+#   Nothing
+zcache-start () {
+    [[ ! -d "$_ZCACHE_PATH" ]] && mkdir -p "$_ZCACHE_PATH"
+    -zcache-hook-antigen
+}
+
+# Generates (if needed) and loads cache.
+#
+# Unhooks antigen commands and removes various zcache functions.
+#
+# Usage
+#   zcache-done
+#
+# Returns
+#   Nothing
+zcache-done () {
+    -zcache-unhook-antigen
+
+    ! zcache-cache-exists && -zcache-generate-cache
+    zcache-load-cache
+
+    unfunction -- -zcache-generate-cache -zcache-antigen-hook -zcache-unhook-antigen \
+    -zcache-hook-antigen zcache-start zcache-done -zcache-antigen -zcache-antigen-apply \
+    -zcache-antigen-bundle -zcache-process-source
+
+    unset _ZCACHE_BUNDLES
+}
+
+# Returns true if cache is available.
+#
+# Usage
+#   zcache-cache-exists
+#
+# Returns
+#   Either 1 if cache exists or 0 if it does not exists
+zcache-cache-exists () {
+    [[ -f "$_ZCACHE_PAYLOAD_PATH" ]]
+}
+
+# Load bundles from cache (sourcing it)
+#
+# This function does not check if cache is available, do use zcache-cache-exists.
+#
+# Usage
+#   zcache-load-cache
+#
+# Returns
+#   Nothing
+zcache-load-cache () {
+    source "$_ZCACHE_PAYLOAD_PATH"
+}
+
+# Removes cache payload and metadata if available
+#
+# Usage
+#   zcache-cache-reset
+#
+# Returns
+#   Nothing
+antigen-cache-reset () {
+    [[ -f "$_ZCACHE_META_PATH" ]] && rm "$_ZCACHE_META_PATH"
+    [[ -f "$_ZCACHE_PAYLOAD_PATH" ]] && rm "$_ZCACHE_PAYLOAD_PATH"
+    echo 'Done. Please open a new shell to see the changes.'
+}
+
+# Antigen command to load antigen configuration
+#
+# This method is slighlty more performing than using various antigen-* methods.
+#
+# Usage
+#   Referencing an antigen configuration file:
+#
+#       antigen-init "/path/to/antigenrc"
+#
+#   or using HEREDOCS:
+#
+#       antigen-init <<EOBUNDLES
+#           antigen use oh-my-zsh
+#
+#           antigen bundle zsh/bundle
+#           antigen bundle zsh/example
+#
+#           antigen theme zsh/theme
+#
+#           antigen apply
+#       EOBUNDLES
+#
+# Returns
+#   Nothing
+antigen-init () {
+    if zcache-cache-exists; then
+        zcache-done
+        return
+    fi
+
+    local src="$1"
+    if [[ -f "$src" ]]; then
+        source "$src"
+        return
+    fi
+
+    grep '^[[:space:]]*[^[:space:]#]' | while read line; do
+        eval $line
+    done
+}

--- a/tests/.antigenrc
+++ b/tests/.antigenrc
@@ -1,0 +1,17 @@
+antigen bundles <<EOBUNDLES
+  git
+  command-not-found
+  colored-man-pages
+  #zsh-users/zsh-autosuggestions
+  zsh-users/zsh-completions
+  #jimhester/per-directory-history
+  #zsh-users/zsh-syntax-highlighting
+  zsh-users/zsh-history-substring-search
+  desyncr/vagrant-zsh-completion
+  felixr/docker-zsh-completion
+  #paoloantinori/hhighlighter h.sh
+EOBUNDLES
+
+antigen theme desyncr/powerlevel9k powerlevel9k --branch=dritter/prezto
+
+antigen apply

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -4,6 +4,9 @@
 
 export ADOTDIR="$PWD/dot-antigen"
 
+export _ANTIGEN_CACHE_PATH="$TESTDIR/.cache"
+export _ANTIGEN_CACHE_ENABLED=false
+
 test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 
 source "$TESTDIR/../antigen.zsh"
@@ -34,6 +37,7 @@ mkdir "$PLUGIN_DIR2"
 alias pg2='git --git-dir "$PLUGIN_DIR2/.git" --work-tree "$PLUGIN_DIR2"'
 
 echo 'alias hehe2="echo hehe2"' > "$PLUGIN_DIR2"/init.zsh
+echo -E 'alias prompt="\e]$ >\a\n"' >> "$PLUGIN_DIR2"/init.zsh
 echo 'alias unsourced-alias="echo unsourced-alias"' > "$PLUGIN_DIR2"/aliases.zsh
 
 {

--- a/tests/.zshrc
+++ b/tests/.zshrc
@@ -1,0 +1,7 @@
+source $ANTIGEN/antigen.zsh
+
+if [[ "$_ANTIGEN_INIT_ENABLED" == "true" ]]; then
+  antigen init $ANTIGEN/tests/.antigenrc
+else
+  source $ANTIGEN/tests/.antigenrc
+fi

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -1,0 +1,68 @@
+Enable extension.
+  $ export _ANTIGEN_CACHE_ENABLED=true
+  $ antigen cache-reset
+  Done. Please open a new shell to see the changes.
+
+  $ antigen list
+  You don't have any bundles.
+  [1]
+
+Add multiple bundles.
+
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles &> /dev/null
+  $ antigen apply &> /dev/null
+
+Check if they are both applied.
+
+  $ hehe
+  hehe
+  $ hehe2
+  hehe2
+
+Cache extension is loaded.
+
+  $ echo $_ZCACHE_EXTENSION_LOADED
+  true
+
+Cache is loaded.
+
+  $ echo $_ZCACHE_CACHE_LOADED
+  true
+
+Should exist cache payload.
+
+  $ ls $_ZCACHE_PAYLOAD_PATH | wc -l
+  1
+
+Should have listed bundles.
+
+  $ antigen-list | wc -l
+  2
+
+  $ ls -A $_ZCACHE_PATH | wc -l
+  2
+
+Both bundles are cached.
+
+  $ cat $_ZCACHE_PAYLOAD_PATH | grep hehe
+  alias hehe="echo hehe"
+  alias hehe2="echo hehe2"
+
+List command should work as expected.
+
+  $ antigen-list
+  */test-plugin / plugin true* (glob)
+  */test-plugin2 / plugin true* (glob)
+
+Respect escape sequences.
+
+  $ cat $_ZCACHE_PAYLOAD_PATH | grep prompt
+  alias prompt="\e]$ >\a\n"
+
+Can clear cache correctly.
+
+  $ antigen cache-reset
+  Done. Please open a new shell to see the changes.
+
+  $ ls -A $_ZCACHE_PATH | wc -l
+  0

--- a/tests/selfupdate.t
+++ b/tests/selfupdate.t
@@ -51,7 +51,7 @@ Use selfupdate from normal repository
      ???????..???????  master     -> origin/master (glob)
   Updating ???????..??????? (glob)
   Fast-forward
-   ver | 2 +-
+   ver |*2 +- (glob)
    1 file changed, 1 insertion(+), 1 deletion(-)
   $ _ANTIGEN_INSTALL_DIR=$TEST_NORMAL antigen-selfupdate
   Already up-to-date.
@@ -63,7 +63,7 @@ Use selfupdate from submodule repository
      ???????..???????  master     -> origin/master (glob)
   Updating ???????..??????? (glob)
   Fast-forward
-   ver | 2 +-
+   ver |*2 +- (glob)
    1 file changed, 1 insertion(+), 1 deletion(-)
   $ _ANTIGEN_INSTALL_DIR=$TEST_SUBMODULE/antigen antigen-selfupdate
   Already up-to-date.


### PR DESCRIPTION
Basic cache implementation following the description given [here](https://github.com/zsh-users/antigen/issues/119).

Very *raw* implementation. All feedback truly appreciated!

To enable/disable set _ANTIGEN_CACHE_ENABLED environment variable apropiately: true or false.

To configure cache path use _ANTIGEN_CACHE_DIR environment variable. By default it's _ANTIGEN_INSTALL_DIR/.cache.

Sample load times on a Intel Core i7 @ 2.40Ghz x 8 64 bit with SSD, antigen configured with [11 extensions](https://github.com/desyncr/zshrc/blob/master/.antigenrc):

    # First time (cache enabled, generates cache)
    $ time zsh
    zsh  0.45s user 0.67s system 119% cpu 0.932 total

    # Second time (cache enable, load from cache)
    $ time zsh
    zsh  0.35s user 0.31s system 113% cpu 0.574 total

    # Cache disabled
    $ export _ANTIGEN_CACHE_ENABLED=false
    $ time zsh
    zsh  0.41s user 0.69s system 119% cpu 0.925 total

## TODO

- [x] ~~Clean cache when bundle is updated/modified~~ Unfeasible. Added commands 'cache-rebuild' and 'cache-clean' for that.
- [x] ~~Intercept expensive calls/functions rather than modify them to add calls to cache-start/cache-done~~ See https://github.com/zsh-users/antigen/pull/133
- [x] Support prezto plugins (See [this](https://github.com/zsh-users/antigen/pull/129/files#diff-af5e58dd8e0859139fb7af9bd8034d85R45))
- [x] Fix all code style issues (indentation, naming, env variables...)
- [x] Add command to rebuild cache, enable/disable cache
- [x] Fix clear-cache messages (extra empty line etc)
- [x] Manage 'antigen bundle' command
- [x] Test on Fedora, CentOS, Debian, Ubuntu, Archlinux, Mac OS X Yosemite. El Capitan
- [x] Remove confirmation prompt for cache-reset command
- [x] Test changing themes, update, revert, snapshot, restore