### PR TITLE
[WIP] Extension system for antigen

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -15,6 +15,9 @@ local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 typeset -a __deferred_compdefs
 compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
 
+# load ext system
+source "$ADOTDIR/ext/extsys.zsh"
+
 # Syntaxes
 #   antigen-bundle <url> [<loc>=/]
 # Keyword only arguments:

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -16,7 +16,7 @@ typeset -a __deferred_compdefs
 compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
 
 # load ext system
-source "$ADOTDIR/ext/extsys.zsh"
+source "$_ANTIGEN_INSTALL_DIR/ext/extsys.zsh"
 
 # Syntaxes
 #   antigen-bundle <url> [<loc>=/]

--- a/ext/antigen-logger.zsh
+++ b/ext/antigen-logger.zsh
@@ -1,0 +1,26 @@
+# logger extension
+# logs bundled stuff
+#
+# TODO add load time per bundle and accumulated load time
+local -a bundles; bundles=()
+
+# register the loaded bundles
+function -antigen-bundle-log () {
+    bundles+=($@)
+}
+
+# logger command that prints the logged bundles
+function antigen-logger () {
+    echo Bundles currently loaded:
+    echo
+    for bundle in $bundles; do
+        echo $bundle
+    done
+    echo
+}
+
+# hooks into antigen-bundle to have access to all 'antigen bundle *' runs
+-ext-hook "antigen-bundle" "-antigen-bundle-log"
+
+# add a completion for the extension
+-ext-compadd "logger"

--- a/ext/antigen-stats.zsh
+++ b/ext/antigen-stats.zsh
@@ -1,0 +1,56 @@
+# stats extension
+#
+# sends a +1 for all bundle installed (effectively counting the number of installs).
+
+# this is a per-bundle count. it doesn't count antigen or per each run.
+# it count each time a bundle is cloned locally.
+#
+# stats are saved per-repository so zsh-git will be different than random-guy/zsh-git
+
+# stats disabled by default
+export _ANTIGEN_STATS=false
+export _ANTIGEN_STATS_SERVER=127.0.0.1
+export _ANTIGEN_STATS_PORT=8125
+
+# not necesary has to identical to -antigen-get-clone-dir
+# in fact we are avoiding local paths that's why we're copying it
+function -stats-get-repo-name () {
+    echo "$1" | sed \
+        -e 's./.-SLASH-.g' \
+        -e 's.:.-COLON-.g' \
+        -e 's.|.-PIPE-.g'
+}
+
+# send 'install' stats to statd server located at "$_ANTIGEN_STATS_SERVER:$_ANTIGEN_STATS_PORT".
+# here we're performing the same check the original 'antigen-ensure-repo' function does,
+# which is checking for the local repository clone; if it's not present we assume it's gonna be installed
+function -stats-grab-stats () {
+    local url=
+    local update=false
+    local verbose=false
+
+    eval "$(-antigen-parse-args 'url ; update?, verbose?' "$@")"
+    shift $#
+
+    local repo_name="$(-antigen-get-clone-dir $url)"
+    if [[ ! -d $repo_name ]]; then
+        -ext-log "installing bundle: $repo_name"
+        local repo_name="$(-stats-get-repo-name $url)"
+        echo "$repo_name:+1|g" | nc -u -w1 $_ANTIGEN_STATS_SERVER $_ANTIGEN_STATS_PORT
+    fi
+}
+
+# hook into ensure-repo function which is reponsible for cloning repos if necesary
+-ext-hook "-antigen-ensure-repo" "-stats-grab-stats"
+
+# function to show the current extension status
+function antigen-stats () {
+    local stats_enabled="disabled"
+    if [[ $_ANTIGEN_STATS ]]; then
+        stats_enabled="enabled"
+    fi
+    echo "Antigen stats are $stats_enabled. Use \$_ANTIGEN_STATS to enable or disable."
+}
+
+# adds above completion
+-ext-compadd "stats"

--- a/ext/extsys.zsh
+++ b/ext/extsys.zsh
@@ -1,0 +1,154 @@
+# Extension system
+#
+# Provides an extension load mechanism for loading custom code that extends antigen.
+#
+# This is different than plugins or themes in a way that it actually interacts with
+# antigen as it can hook into different antigen commands and internal/private functions.
+#
+# It provides pre- and post- hooks for any function (currently even outside antigen). Effectively
+# executing the pre-function, the function itself and a post-function.
+#
+# It doesn't short-circuit (meaning it will always call all hooks and the actual command/function).
+#
+# Usage:
+#
+#       antigen ext ext-name # loads (ie, sources) the given extension from $ADOTDIR/ext/
+#
+# These are only meant to be run inside extension definitions:
+#
+#       # overwrites 'any-antigen-function' (ex, antigen-bundle) with 'extension-hook-function'
+#       # which could be any function already defined.
+#       # it can hook into pre- or post- events. defaults to pre-.
+#       -ext-hook "any-antigen-function" "extension-hook-function" ["pre"|"post"]
+#
+#       # defined a new autocompletion for the antigen command (ex, antigen logger)
+#       -ext-compadd "extension-auto-completion"
+#
+# The hooks functions receives the same arguments the original function receives.
+typeset -A callbacks
+local -a hooks; hooks=()
+
+# enable or disable logging
+export _EXT_LOGGING_ENABLED=false
+
+# logs a custom message (echo to >&2)
+#
+# usage:
+#   -ext-log "message"          # LOG: message
+#   -ext-log -e "error message" # ERROR: error message
+#
+# enable or disable logging with $_EXT_LOGGING_ENABLED env variable
+function -ext-log () {
+    local message
+    if [[ $1 == "-e" ]]; then
+        shift
+        message="ERROR: $@"
+    else
+        message="LOG: $@"
+    fi
+
+    if ($_EXT_LOGGING_ENABLED) {
+        echo "$message" >&2
+    }
+}
+
+# function wrapper for -ext-log to display "ERROR: " labeled logs
+#
+# usage:
+#   -ext-log-error "error"  # ERROR: error
+function -ext-log-error () {
+    -ext-log "-e" "$@"
+}
+
+# capture functions providing a pre and post callbacks
+#
+# usage:
+#   -ext-capture "func-name"
+#
+# captures 'func-name' and registers it into $hooks list
+function -ext-capture () {
+    local funcname="$1"
+    eval "function -captured-$(functions -- $funcname)"
+
+    -ext-log capturing function $funcname
+    hooks+=($funcname)
+
+    $funcname () {
+        callback="$0"
+        call-hooks () {
+            local hook_name="$1-$2"
+            local names=${callbacks[$hook_name]}
+            for hook in ${(s.:.)names}; do
+                -ext-log calling hook function $hook for $hook_name
+                eval "$hook" "$3"
+            done
+        }
+
+        # calling pre hooks
+        call-hooks "$callback" "pre" "$@"
+
+        # we call the captured function
+        -captured-$0 $@
+
+        # calling post hooks
+        call-hooks "$callback" "post" "$@"
+    }
+}
+
+# hooks a particular function
+#
+# usage:
+#   -antigen-hook "antigen-bundle" "antigen-bundle-hook"    # hooks antigen-bundle (pre event)
+#   -antigen-hook "antigen-bundle" "antigen-bundle-hook" "post" #hooks antigen-bundle (post event)
+#
+# if the function to be hooked wasn't captured it captures it with -ext-capture
+function -ext-hook () {
+    local function_hook="$1"
+    local callback_function="$2"
+    local event="$3"
+
+    if [ ! "$event" ]; then
+        event="pre"
+    fi
+
+    local hook_name="$function_hook-$event"
+
+    callbacks[$hook_name]=${callbacks[$hook_name]}"$callback_function:"
+
+    if [[ ! -n "${hooks[(r)$function_hook]}" ]]; then
+        -ext-capture $function_hook
+    else
+        -ext-log already hooked function $function_hook
+    fi
+
+    -ext-log registering callback for function hook $hook_name as $callback_function
+}
+
+# adds an autocompletion to antigen command
+#
+# usage:
+#   -ext-compadd "extension-command"
+function -ext-compadd () {
+    local compadd_function="compadd-ext-$1"
+    eval "function $compadd_function () {
+        compadd "$1"
+    }"
+    -ext-hook "_antigen" $compadd_function
+}
+
+# loads a given extension (ie, sources it)
+#
+# usage:
+#   antigen ext "extname"
+#
+# it the extension is not found it logs the error and moves along
+function antigen-ext () {
+    local extension_name="$1"
+    local extension_path="$ADOTDIR/ext/$1.zsh"
+    -ext-log loading extension "$extension_name" from $extension_path
+    if [ -e "$extension_path" ]; then
+        source "$extension_path"
+    else
+        -ext-log-error "No extension found!: $extension_name ($extension_path)"
+    fi
+}

--- a/ext/extsys.zsh
+++ b/ext/extsys.zsh
@@ -12,7 +12,7 @@
 #
 # Usage:
 #
-#       antigen ext ext-name # loads (ie, sources) the given extension from $ADOTDIR/ext/
+#       antigen ext ext-name # loads (ie, sources) the given extension from $_ANTIGEN_INSTALL_DIR/ext/
 #
 # These are only meant to be run inside extension definitions:
 #
@@ -144,7 +144,7 @@ function -ext-compadd () {
 # it the extension is not found it logs the error and moves along
 function antigen-ext () {
     local extension_name="$1"
-    local extension_path="$ADOTDIR/ext/$1.zsh"
+    local extension_path="$_ANTIGEN_INSTALL_DIR/ext/$1.zsh"
     -ext-log loading extension "$extension_name" from $extension_path
     if [ -e "$extension_path" ]; then
         source "$extension_path"


### PR DESCRIPTION
Provides an extension load mechanism for loading custom code that extends antigen.

This is different than plugins or themes in a way that it actually interacts with
antigen as it can hook into different antigen commands and internal/private functions.

It provides pre- and post- hooks for any function (currently even outside antigen). Effectively
executing the pre-function, the function itself and a post-function.

It doesn't short-circuit (meaning it will always call all hooks and the actual command/function).

Usage:

      antigen ext ext-name # loads (ie, sources) the given extension from $ADOTDIR/ext/

These are only meant to be run inside extension definitions:

      # overwrites 'any-antigen-function' (ex, antigen-bundle) with 'extension-hook-function'
      # which could be any function already defined.
      # it can hook into pre- or post- events. defaults to pre-.
      -ext-hook "any-antigen-function" "extension-hook-function" ["pre"|"post"]

      # defined a new autocompletion for the antigen command (ex, antigen logger)
      -ext-compadd "extension-auto-completion"

The hooks functions receives the same arguments the original function receives.

Also added ext/antigen-logger.zsh and ext/antigen-stats.zsh which are only sample extensions that provides a logging for bundles (antigen-logger) and kind-of stats as described [here](https://github.com/zsh-users/antigen/pull/83). These extensions are not meant to be shipped in the code base just samples for anyone who want's to try this PR out.

Example .zshrc configuration:

    export ADOTDIR=$HOME/.antigen                # path to antigen
    export _EXT_LOGGING_ENABLED=false
    source $ADOTDIR/antigen.zsh
    source $HOME/.antigenrc

Example .antigenrc configuration:

    antigen ext antigen-logger
    antigen ext antigen-stats
    antigen bundle zsh-users/zsh-syntax-highlighting
    antigen apply

All feedback is welcomed.

# TODO

- [ ] Use antigen-bundle to load extensions (if ext is not built-in) 
- [ ] Move antigen-logger and antigen-stats to it's own repos
- [ ] Add tests

