### PR TITLE
Remove trailing slash from ZDOTDIR assignment

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -404,7 +404,7 @@ antigen-use () {
 
 -antigen-use-prezto () {
     antigen-bundle sorin-ionescu/prezto
-    export ZDOTDIR=$ADOTDIR/repos/
+    export ZDOTDIR=$ADOTDIR/repos
 }
 
 # For backwards compatibility.


### PR DESCRIPTION
For compatibility with Prezto