### PR TITLE
Modify ZDOTDIR before loading Prezto

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -403,8 +403,8 @@ antigen-use () {
 }
 
 -antigen-use-prezto () {
+    export ZDOTDIR=$ADOTDIR/repos
     antigen-bundle sorin-ionescu/prezto
-    export ZDOTDIR=$ADOTDIR/repos/
 }
 
 # For backwards compatibility.


### PR DESCRIPTION
This allows you to keep your existing .zpreztorc file. Otherwise, with `ZDOTDIR` incorrectly set, Prezto's init.zsh will fail to load packages specified in .zpreztorc, which is the usual Prezto way. This means that Prezto users can keep their configuration files if they decide to switch to Antigen.