### PR TITLE
Improve overall plugins load performance

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -129,8 +129,8 @@ antigen-update () {
                     git rev-parse HEAD) >> $ADOTDIR/revert-info
             fi
 
-            update=true verbose=true \
-                -antigen-ensure-repo "$url" $update $verbose
+            # update=true verbose=true
+            -antigen-ensure-repo "$url" true true
 
             echo
         done

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -129,7 +129,8 @@ antigen-update () {
                     git rev-parse HEAD) >> $ADOTDIR/revert-info
             fi
 
-            -antigen-ensure-repo "$url" --update --verbose
+            update=true verbose=true \
+                -antigen-ensure-repo "$url" $update $verbose
 
             echo
         done
@@ -192,19 +193,20 @@ antigen-revert () {
 -antigen-ensure-repo () {
 
     # Ensure that a clone exists for the given repo url and branch. If the first
-    # argument is `--update` and if a clone already exists for the given repo
+    # This function expects three arguments in order:
+    # * 'url=<url>'
+    # * 'update=true|false'
+    # * 'verbose=true|false'
+    # argument is `update` and if a clone already exists for the given repo
     # and branch, it is pull-ed, i.e., updated.
 
     # Argument defaults.
     # The url. No sane default for this, so just empty.
-    local url=
+    local url=${1:?"url must be set"}
     # Check if we have to update.
-    local update=false
+    local update=${2:-false}
     # Verbose output.
-    local verbose=false
-
-    eval "$(-antigen-parse-args 'url ; update?, verbose?' "$@")"
-    shift $#
+    local verbose=${3:-false}
 
     # Get the clone's directory as per the given repo url and branch.
     local clone_dir="$(-antigen-get-clone-dir $url)"

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -208,6 +208,8 @@ antigen-revert () {
     # Verbose output.
     local verbose=${3:-false}
 
+    shift $#
+
     # Get the clone's directory as per the given repo url and branch.
     local clone_dir="$(-antigen-get-clone-dir $url)"
 


### PR DESCRIPTION
-antigen-parse-args is very expensive. Avoiding using it in internal calls improve overall performance.
Instead of using -antigen-parse-args just invoke functions with arguments in expected order.

I got 50% performance improvement.