### PR TITLE
Let plugins set environment variables at login

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -325,6 +325,32 @@ Takes no options.
 Insider detail: The information for reverting is stored in
 `$ADOTDIR/revert-info` file.  If its not present, reverting is not possible.
 
+### antigen env
+
+Some plugins set environment variables at login time, e.g. to add commands to
+your `PATH` so they are available to all the programs in your session, not just
+those started from an interactive shell. Call `antigen env` on those plugins
+from your `.profile` to set everything up:
+
+    antigen env <url>
+
+You still need to call `antigen bundle` in your `.zshrc`, as usual, for these
+plugins.
+
+A typical `.profile` might look like this
+
+    # Note that .profile is often sourced by /bin/sh, so it has to be POSIX
+    # shell compatible. Unfortunately, this also means we have to explicitly
+    # tell antigen where it is using this environment variable.
+    export ANTIGEN_INSTALL_DIR=/path-to-antigen-clone
+    . "$ANTIGEN_INSTALL_DIR/antigen-env.sh"
+
+    antigen env zsh-users/zsh-syntax-highlighting
+
+If you don't care about setting environment variables at login time, just use
+`antigen bundle` as normal, and antigen will make sure those packages are set
+up correctly by the time you get to an interactive shell.
+
 ### antigen list
 
 Use this command to list out the currently *loaded* plugins. Keep in mind that
@@ -565,6 +591,15 @@ in it are loaded.
 One exception to this rule is that if this plugin is a theme. In which case the
 theme script is just sourced and nothing else is done. Not even adding to
 `$fpath`.
+
+If your plugin sets the `PATH` or other environment variables, consider
+setting these in a separate `*.plugin.env.sh` file. This lets the variables
+be set at login using `antigen env`, so they are visible to all the programs in
+a graphical session, not just the ones started from an interactive shell. The
+only caveat is that `*.plugin.env.sh` must be POSIX-shell compatible. Anything
+which is only relevant to interactive shells (such as aliases) should go in the
+usual files. The `*.plugin.env.sh` will still be loaded for interactive shells,
+even if you don't use `antigen env`.
 
 ## A note on external zsh plugins
 

--- a/antigen-env.sh
+++ b/antigen-env.sh
@@ -1,0 +1,50 @@
+# Setup environment variables from antigen plugins at login time, so they are
+# available to all programs in the session, not just those launched from an
+# interactive shell. To use, source this script from .profile.
+#
+# This file must be POSIX-shell compatible, since .profile is sourced by
+# /bin/sh, which is often dash (or at least, not zsh).
+#
+
+# Should really be called antigen-env, but dash doesn't like functions with
+# hyphens in the name.
+antigenenv () {
+    # We have to use this ugly style since POSIX shell doesn't do process
+    # substitution, and the while loop has to be in this shell, not a subshell.
+    local tmp="$(mktemp)"
+
+    zsh -s "$@" > "$tmp" <<'EOF'
+# Because the parent script is sourced by /bin/sh, we can't programmatically
+# work out where the real antigen is - even though this script is in the same
+# directory as it!
+[[ -z "$ANTIGEN_INSTALL_DIR" ]] && exit 0
+source "$ANTIGEN_INSTALL_DIR/antigen.zsh"
+-antigen-get-env-scripts-and-locations "$@"
+EOF
+
+    local plugin=''
+    local script=''
+    while IFS='|' read plugin script; do
+        ANTIGEN_THIS_PLUGIN_DIR="$plugin"
+        . "$script"
+        unset ANTIGEN_THIS_PLUGIN_DIR
+        export ANTIGEN_PLUGINS_ENVED="$ANTIGEN_PLUGINS_ENVED:$plugin"
+    done < "$tmp"
+
+    rm "$tmp"
+}
+
+antigen () {
+    local cmd="$1"
+    if [ -z "$cmd" ]; then
+        echo 'Antigen: Please give a command to run.' >&2
+        return 1
+    fi
+    shift
+
+    if [ "$cmd" = 'env' ]; then
+        antigenenv "$@"
+    else
+        echo "Antigen: Inapplicable command: $cmd; only 'antigen env' can be run at this time" >&2
+    fi
+}

--- a/antigen-env.sh
+++ b/antigen-env.sh
@@ -29,6 +29,7 @@ EOF
         . "$script"
         unset ANTIGEN_THIS_PLUGIN_DIR
         export ANTIGEN_PLUGINS_ENVED="$ANTIGEN_PLUGINS_ENVED:$plugin"
+        export ANTIGEN_SCRIPTS_ENVED="$ANTIGEN_SCRIPTS_ENVED:$script"
     done < "$tmp"
 
     rm "$tmp"

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -171,6 +171,7 @@ antigen-env () {
             unset ANTIGEN_THIS_PLUGIN_DIR
         fi
         export ANTIGEN_PLUGINS_ENVED="$ANTIGEN_PLUGINS_ENVED:$location"
+        export ANTIGEN_SCRIPTS_ENVED="$ANTIGEN_SCRIPTS_ENVED:$env_script"
     fi
 }
 
@@ -347,8 +348,13 @@ antigen-env () {
 
         elif ls "$location" | grep -l '\.sh$' &> /dev/null; then
             # If there are no `*.zsh` files either, we look for and source any
-            # `*.sh` files instead.
-            for script ($location/*.sh(N)) { source "$script" }
+            # `*.sh` files instead - but only if they haven't already been
+            # sourced by antigen-env.
+            for script ($location/*.sh(N)) {
+                    if ! [[ "$ANTIGEN_SCRIPTS_ENVED" =~ "$(readlink -m "$script")" ]]; then
+                        source "$script"
+                    fi
+                }
 
         fi
 


### PR DESCRIPTION
For some plugins it's useful to set environment variables at login time, e.g. to add commands to the `PATH` so they are available to all the programs in a graphical session, not just ones launched from an interactive shell. This patch adds a new command, `antigen env`, which can be called from your `.profile` to do this. It looks for a `*.plugin.env.sh` file and sources it (`antigen bundle` still sources the usual files).

An example of how this would be used is at https://github.com/CallumCameron/emacs-launchers, where the `PATH` is set in `emacs-launchers.plugin.env.sh` so that the scripts in the repo are accessible from the desktop even when you are not in a shell, but the aliases are set in `emacs-launchers.plugin.zsh` where they are needed. It lets antigen be used more generally as a sort of 'github package manager', rather than just for zsh.

This is completely backwards compatible - if a plugin has a `*.plugin.env.sh` file, but the user doesn't need/care about setting things at login time, then `antigen bundle` will source the new file at the right time, and everything will work properly, as before.