### PR TITLE
fix fpath duplicates

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -303,7 +303,7 @@ antigen-revert () {
         fi
 
         # Add to $fpath, for completion(s), if not in there already
-        if [[ $#fpath[(r)$location] == 0 ]]; then
+        if (( ! ${fpath[(I)$location]} )); then
             fpath=($location $fpath)
         fi
 

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -302,8 +302,10 @@ antigen-revert () {
 
         fi
 
-        # Add to $fpath, for completion(s).
-        fpath=($location $fpath)
+        # Add to $fpath, for completion(s), if not in there already
+        if [[ $#fpath[(r)$location] == 0 ]]; then
+            fpath=($location $fpath)
+        fi
 
     fi
 


### PR DESCRIPTION
antigen adds a bundle into fpath upon every loading operation. this leads to duplicates of all bundles loaded from .zshrc if .zshrc is sourced again later, which impacts performance. my tiny fix simply checks if a bundle's path is in fpath already and adds it only if that is not the case.