### PR TITLE
Fix antigen-update if noclobber is set in zsh

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -114,7 +114,7 @@ antigen-bundles () {
 antigen-update () {
     # Update your bundles, i.e., `git pull` in all the plugin repos.
 
-    date > $ADOTDIR/revert-info
+    date >! $ADOTDIR/revert-info
 
     -antigen-echo-record |
         awk '$4 == "true" {print $1}' |


### PR DESCRIPTION
When noclobber is set in zsh, the second and all following "antigen
update' may face issues as the revert date is not correctly written to
the file.

As a reminder, noclobber unsets the CLOBBER flag. When the flag is not
set, existing files cannot be truncated when using a simple ">"
redirection, and it needs to be forced with ">!".