### PR TITLE
Change default directory to comply to XDG standard

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -726,7 +726,11 @@ antigen () {
     # Pre-startup initializations.
     -set-default ANTIGEN_DEFAULT_REPO_URL \
         https://github.com/robbyrussell/oh-my-zsh.git
-    -set-default ADOTDIR $HOME/.antigen
+    if [[ -z $XDG_CONFIG_DIR ]]; then
+        -set-default ADOTDIR $HOME/.config/antigen
+    else
+        -set-default ADOTDIR $XDG_CONFIG_DIR/antigen
+    fi
 
     # Setup antigen's own completion.
     compdef _antigen antigen


### PR DESCRIPTION
As a user, I want all software to comply to XDG. Thus, in the future my home dir will be more clean and organized.