### PR TITLE
[BUGFIX] Load antigen completions at load time

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -739,6 +739,8 @@ antigen () {
     -set-default ADOTDIR $HOME/.antigen
 
     # Setup antigen's own completion.
+    autoload -U compinit
+    compinit -C
     compdef _antigen antigen
 
     # Remove private functions.


### PR DESCRIPTION
When installing antigen there are no autocompletions available.