### PR TITLE
Fix sed replacement for \NL \n

### DIFF
--- a/ext/zcache.zsh
+++ b/ext/zcache.zsh
@@ -66,7 +66,7 @@ local -a _ZCACHE_BUNDLES
     _payload+="export _ZCACHE_CACHE_LOADED=true\NL"
     _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
-    echo -E $_payload | sed 's/\\NL/\n/g' >>! $_ZCACHE_PAYLOAD_PATH
+    echo -E $_payload | sed 's/\\NL/\'$'\n/g' >>! $_ZCACHE_PAYLOAD_PATH
     echo "${(j:\n:)_bundles_meta}" >>! $_ZCACHE_META_PATH
 }
 


### PR DESCRIPTION
Sed's BSD doesn't seem to work with escape sequences. Should work on BSD and GNU the same.