### PR TITLE
Autodetect antigen configuration changes

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -12,6 +12,7 @@ local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}
 local _ANTIGEN_INTERACTIVE=${_ANTIGEN_INTERACTIVE_MODE:-false}
+local _ANTIGEN_AUTODETECT_CONFIG_CHANGES=${_ANTIGEN_AUTODETECT_CONFIG_CHANGES:-true}
 
 # Do not load anything if git is no available.
 if ! which git &> /dev/null; then
@@ -915,7 +916,8 @@ _antigen () {
 -antigen-env-setup
 export _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
 export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
-export _ZCACHE_META_PATH="$_ZCACHE_PATH/.zcache-meta"
+export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
+export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
 local -a _ZCACHE_BUNDLES
 
@@ -998,8 +1000,8 @@ local -a _ZCACHE_BUNDLES
     _payload+="export _ZCACHE_CACHE_VERSION=v1.1.4\NL"
     _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
-    echo -E $_payload | sed 's/\\NL/\'$'\n/g' >>! $_ZCACHE_PAYLOAD_PATH
-    echo "${(j:\n:)_bundles_meta}" >>! $_ZCACHE_META_PATH
+    echo -E $_payload | sed 's/\\NL/\'$'\n/g' >>! "$_ZCACHE_PAYLOAD_PATH"
+    echo "$_ZCACHE_BUNDLES" >! "$_ZCACHE_BUNDLES_PATH"
 }
 
 # Generic hook function for various antigen-* commands.
@@ -1102,6 +1104,17 @@ local -a _ZCACHE_BUNDLES
     return _ANTIGEN_INTERACTIVE
 }
 
+# Determines if cache is up-to-date with antigen configuration
+#
+# Usage
+#   -zcache-cache-invalidated
+#
+# Returns
+#   Either true or false depending if cache is up to date
+-zcache-cache-invalidated () {
+    [[ $_ANTIGEN_AUTODETECT_CONFIG_CHANGES == true && $(cat $_ZCACHE_BUNDLES_PATH) != "$_ZCACHE_BUNDLES" ]];
+}
+
 # Starts zcache execution.
 #
 # Hooks into various antigen commands to be able to record and cache multiple
@@ -1143,12 +1156,14 @@ zcache-done () {
     unset _ZCACHE_EXTENSION_ACTIVE
     
     -zcache-unhook-antigen
-    if [[ ${#_ZCACHE_BUNDLES} -gt 0 ]]; then
-        ! zcache-cache-exists && -zcache-generate-cache
-        zcache-load-cache
+    if ! zcache-cache-exists || -zcache-cache-invalidated; then
+        -zcache-generate-cache
     fi
+    zcache-load-cache
     
-    unfunction -- ${(Mok)functions:#-zcache*}
+    if [[ $_ZCACHE_EXTENSION_CLEAN_FUNCTIONS == true ]]; then
+        unfunction -- ${(Mok)functions:#-zcache*}
+    fi
 
     eval "function -zcache-$(functions -- antigen-update)"
     antigen-update () {
@@ -1192,8 +1207,10 @@ zcache-load-cache () {
 # Returns
 #   Nothing
 antigen-cache-reset () {
-    [[ -f "$_ZCACHE_META_PATH" ]] && rm "$_ZCACHE_META_PATH"
-    [[ -f "$_ZCACHE_PAYLOAD_PATH" ]] && rm "$_ZCACHE_PAYLOAD_PATH"
+    -zcache-remove-path () { [[ -f "$1" ]] && rm "$1" }
+    -zcache-remove-path "$_ZCACHE_PAYLOAD_PATH"
+    -zcache-remove-path "$_ZCACHE_BUNDLES_PATH"
+    unfunction -- -zcache-remove-path
     echo 'Done. Please open a new shell to see the changes.'
 }
 

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1156,10 +1156,13 @@ zcache-done () {
     unset _ZCACHE_EXTENSION_ACTIVE
     
     -zcache-unhook-antigen
-    if ! zcache-cache-exists || -zcache-cache-invalidated; then
-        -zcache-generate-cache
+    if [[ ${#_ZCACHE_BUNDLES} -gt 0 ]]; then
+        if ! zcache-cache-exists || -zcache-cache-invalidated; then
+            -zcache-generate-cache
+        fi
+        
+        zcache-load-cache
     fi
-    zcache-load-cache
     
     if [[ $_ZCACHE_EXTENSION_CLEAN_FUNCTIONS == true ]]; then
         unfunction -- ${(Mok)functions:#-zcache*}

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -12,6 +12,7 @@ local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}
 local _ANTIGEN_INTERACTIVE=${_ANTIGEN_INTERACTIVE_MODE:-false}
+local _ANTIGEN_AUTODETECT_CONFIG_CHANGES=${_ANTIGEN_AUTODETECT_CONFIG_CHANGES:-true}
 
 # Do not load anything if git is no available.
 if ! which git &> /dev/null; then

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -1,6 +1,7 @@
 export _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
 export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
-export _ZCACHE_META_PATH="$_ZCACHE_PATH/.zcache-meta"
+export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
+export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
 local -a _ZCACHE_BUNDLES
 
@@ -83,8 +84,8 @@ local -a _ZCACHE_BUNDLES
     _payload+="export _ZCACHE_CACHE_VERSION={{ANTIGEN_VERSION}}\NL"
     _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
-    echo -E $_payload | sed 's/\\NL/\'$'\n/g' >>! $_ZCACHE_PAYLOAD_PATH
-    echo "${(j:\n:)_bundles_meta}" >>! $_ZCACHE_META_PATH
+    echo -E $_payload | sed 's/\\NL/\'$'\n/g' >>! "$_ZCACHE_PAYLOAD_PATH"
+    echo "$_ZCACHE_BUNDLES" >! "$_ZCACHE_BUNDLES_PATH"
 }
 
 # Generic hook function for various antigen-* commands.
@@ -187,6 +188,17 @@ local -a _ZCACHE_BUNDLES
     return _ANTIGEN_INTERACTIVE
 }
 
+# Determines if cache is up-to-date with antigen configuration
+#
+# Usage
+#   -zcache-cache-invalidated
+#
+# Returns
+#   Either true or false depending if cache is up to date
+-zcache-cache-invalidated () {
+    [[ $_ANTIGEN_AUTODETECT_CONFIG_CHANGES == true && $(cat $_ZCACHE_BUNDLES_PATH) != "$_ZCACHE_BUNDLES" ]];
+}
+
 # Starts zcache execution.
 #
 # Hooks into various antigen commands to be able to record and cache multiple
@@ -228,12 +240,14 @@ zcache-done () {
     unset _ZCACHE_EXTENSION_ACTIVE
     
     -zcache-unhook-antigen
-    if [[ ${#_ZCACHE_BUNDLES} -gt 0 ]]; then
-        ! zcache-cache-exists && -zcache-generate-cache
-        zcache-load-cache
+    if ! zcache-cache-exists || -zcache-cache-invalidated; then
+        -zcache-generate-cache
     fi
+    zcache-load-cache
     
-    unfunction -- ${(Mok)functions:#-zcache*}
+    if [[ $_ZCACHE_EXTENSION_CLEAN_FUNCTIONS == true ]]; then
+        unfunction -- ${(Mok)functions:#-zcache*}
+    fi
 
     eval "function -zcache-$(functions -- antigen-update)"
     antigen-update () {
@@ -277,8 +291,10 @@ zcache-load-cache () {
 # Returns
 #   Nothing
 antigen-cache-reset () {
-    [[ -f "$_ZCACHE_META_PATH" ]] && rm "$_ZCACHE_META_PATH"
-    [[ -f "$_ZCACHE_PAYLOAD_PATH" ]] && rm "$_ZCACHE_PAYLOAD_PATH"
+    -zcache-remove-path () { [[ -f "$1" ]] && rm "$1" }
+    -zcache-remove-path "$_ZCACHE_PAYLOAD_PATH"
+    -zcache-remove-path "$_ZCACHE_BUNDLES_PATH"
+    unfunction -- -zcache-remove-path
     echo 'Done. Please open a new shell to see the changes.'
 }
 

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -240,10 +240,15 @@ zcache-done () {
     unset _ZCACHE_EXTENSION_ACTIVE
     
     -zcache-unhook-antigen
-    if ! zcache-cache-exists || -zcache-cache-invalidated; then
-        -zcache-generate-cache
+    
+    # Avoids seg fault on zsh 4.3.5
+    if [[ ${#_ZCACHE_BUNDLES} -gt 0 ]]; then
+        if ! zcache-cache-exists || -zcache-cache-invalidated; then
+            -zcache-generate-cache
+        fi
+        
+        zcache-load-cache
     fi
-    zcache-load-cache
     
     if [[ $_ZCACHE_EXTENSION_CLEAN_FUNCTIONS == true ]]; then
         unfunction -- ${(Mok)functions:#-zcache*}

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -7,6 +7,7 @@ export ADOTDIR="$PWD/dot-antigen"
 
 export _ANTIGEN_CACHE_ENABLED=true
 export _ANTIGEN_INTERACTIVE_MODE=true
+export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS=false
 
 test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -74,20 +74,19 @@ Cache is invalidated on antigen configuration changes.
 
   $ unset _ZCACHE_EXTENSION_ACTIVE  
   $ zcache-start # forces non-interactive mode
-  $ antigen cache-reset
-  Done. Please open a new shell to see the changes.
+  $ antigen cache-reset &> /dev/null
 
   $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles
   $ antigen apply
 
   $ unset _ZCACHE_EXTENSION_ACTIVE  
-  $ zcache-start # forces non-interactive mode
+  $ zcache-start
   $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles
   $ antigen apply
   $ bundles=$(cat $_ZCACHE_BUNDLES_PATH)
 
   $ unset _ZCACHE_EXTENSION_ACTIVE  
-  $ zcache-start # forces non-interactive mode
+  $ zcache-start
   $ echo "$PLUGIN_DIR2\n$PLUGIN_DIR" | antigen-bundles
   $ antigen apply
   $ [[ "$bundles" == $(cat $_ZCACHE_BUNDLES_PATH) ]]
@@ -101,6 +100,12 @@ Cache version matches antigen version.
 
   $ if [[ "$ANTIGEN_VERSION" == "$_ZCACHE_CACHE_VERSION" ]]; then echo 1; else echo 0; fi
   1
+
+Do not generate or load cache if there are no bundles.
+
+  $ antigen cache-reset &> /dev/null
+  $ ls -A $_ZCACHE_PATH | wc -l
+  0
 
 Can clear cache correctly.
 

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -70,6 +70,29 @@ Cache is saved correctly.
   $ cat $_ZCACHE_PAYLOAD_PATH | grep -Pc 'echo \$root/\$0'
   1
 
+Cache is invalidated on antigen configuration changes.
+
+  $ unset _ZCACHE_EXTENSION_ACTIVE  
+  $ zcache-start # forces non-interactive mode
+  $ antigen cache-reset
+  Done. Please open a new shell to see the changes.
+
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles
+  $ antigen apply
+
+  $ unset _ZCACHE_EXTENSION_ACTIVE  
+  $ zcache-start # forces non-interactive mode
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles
+  $ antigen apply
+  $ bundles=$(cat $_ZCACHE_BUNDLES_PATH)
+
+  $ unset _ZCACHE_EXTENSION_ACTIVE  
+  $ zcache-start # forces non-interactive mode
+  $ echo "$PLUGIN_DIR2\n$PLUGIN_DIR" | antigen-bundles
+  $ antigen apply
+  $ [[ "$bundles" == $(cat $_ZCACHE_BUNDLES_PATH) ]]
+  [1]
+
 Cache version matches antigen version.
 
   $ ANTIGEN_VERSION=$(antigen version | sed 's/Antigen //')


### PR DESCRIPTION
Detect antigen bundle changes in order to perform a cache-reset automatically upon change detection.

This will allow users to freely tweak their antigen bundle configurations (themes, bundles, etc) and see changes without needing to issue cache-reset command.

Antigen now saves a .zcache-bundles file with bundle configuration in order to compare for changes. When a change is made to the bundles (changing the order bundles are loaded, adding or removing etc) antigen will regenerate cache on the fly and changes will be available right away.

In order to disable this functionality set _ANTIGEN_AUTODETECT_CONFIG_CHANGES environment variable to false.
Fixes #256 