### PR TITLE
Deprecate antigen cache-reset command

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1181,12 +1181,24 @@ zcache-load-cache () {
 #
 # Returns
 #   Nothing
-antigen-cache-reset () {
+antigen-reset () {
     -zcache-remove-path () { [[ -f "$1" ]] && rm "$1" }
     -zcache-remove-path "$_ZCACHE_PAYLOAD_PATH"
     -zcache-remove-path "$_ZCACHE_BUNDLES_PATH"
     unfunction -- -zcache-remove-path
     echo 'Done. Please open a new shell to see the changes.'
+}
+
+# Deprecated for antigen-reset command
+#
+# Usage
+#   zcache-cache-reset
+#
+# Returns
+#   Nothing
+antigen-cache-reset () {
+    echo 'Deprecated in favor of antigen reset.'
+    antigen-reset
 }
 
 # Antigen command to load antigen configuration

--- a/src/_antigen
+++ b/src/_antigen
@@ -19,7 +19,7 @@ _antigen () {
 
   if $_ANTIGEN_CACHE_ENABLED; then
       _1st_arguments+=(
-      'cache-reset:Clears bundle cache'
+      'reset:Clears antigen cache'
       'init:Load Antigen configuration from file'
       )
   fi

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -101,12 +101,24 @@ zcache-load-cache () {
 #
 # Returns
 #   Nothing
-antigen-cache-reset () {
+antigen-reset () {
     -zcache-remove-path () { [[ -f "$1" ]] && rm "$1" }
     -zcache-remove-path "$_ZCACHE_PAYLOAD_PATH"
     -zcache-remove-path "$_ZCACHE_BUNDLES_PATH"
     unfunction -- -zcache-remove-path
     echo 'Done. Please open a new shell to see the changes.'
+}
+
+# Deprecated for antigen-reset command
+#
+# Usage
+#   zcache-cache-reset
+#
+# Returns
+#   Nothing
+antigen-cache-reset () {
+    echo 'Deprecated in favor of antigen reset.'
+    antigen-reset
 }
 
 # Antigen command to load antigen configuration

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -2,7 +2,7 @@ Enable extension.
 
   $ unset _ZCACHE_EXTENSION_ACTIVE
   $ zcache-start # forces non-interactive mode
-  $ antigen cache-reset
+  $ antigen reset
   Done. Please open a new shell to see the changes.
 
   $ antigen list
@@ -74,7 +74,7 @@ Cache is invalidated on antigen configuration changes.
 
   $ unset _ZCACHE_EXTENSION_ACTIVE  
   $ zcache-start # forces non-interactive mode
-  $ antigen cache-reset &> /dev/null
+  $ antigen reset &> /dev/null
 
   $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles
   $ antigen apply
@@ -103,13 +103,19 @@ Cache version matches antigen version.
 
 Do not generate or load cache if there are no bundles.
 
-  $ antigen cache-reset &> /dev/null
+  $ antigen reset &> /dev/null
   $ ls -A $_ZCACHE_PATH | wc -l
   0
 
-Can clear cache correctly.
+Antigen cache-reset command deprecated.
 
   $ antigen cache-reset
+  Deprecated in favor of antigen reset.
+  Done. Please open a new shell to see the changes.
+
+Can clear cache correctly.
+
+  $ antigen reset
   Done. Please open a new shell to see the changes.
 
   $ ls -A $_ZCACHE_PATH | wc -l


### PR DESCRIPTION
Deprecated in favor of antigen reset. cache-reset is still
available but the following message will be issued upon running it:

    Deprecated in favor of antigen reset.

Use antigen reset command instead. Command will be unavailable on next
major version.

Fixes #258 