### PR TITLE
Antigen fast boot method for bundle loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ revert-info
 
 # Default antigen.log location
 *.log
+
+# Ignore compiled zsh files
+*.zwc

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ install:
 
 build:
 	cat ${PROJECT}/src/antigen.zsh > ${BIN}/antigen.zsh
+	cat ${PROJECT}/src/boot.zsh >> ${BIN}/antigen.zsh
 	cat ${PROJECT}/src/helpers/*.zsh >> ${BIN}/antigen.zsh
 	cat ${PROJECT}/src/lib/*.zsh >> ${BIN}/antigen.zsh
 	cat ${PROJECT}/src/commands/*.zsh >> ${BIN}/antigen.zsh

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -491,14 +491,14 @@ antigen-apply () {
     # the one that actually initializes completions.
     autoload -Uz compinit
     compinit -iCd $ANTIGEN_COMPDUMPFILE
-    if [[ ! -f "$_ANTIGEN_COMPDUMPFILE.zwc" ]]; then
+    if [[ ! -f "$ANTIGEN_COMPDUMPFILE.zwc" ]]; then
         # Apply all `compinit`s that have been deferred.
         local cdef
         for cdef in "${__deferred_compdefs[@]}"; do
             compdef "$cdef"
         done
-        
-        zcompile $_ANTIGEN_COMPDUMPFILE
+
+        zcompile $ANTIGEN_COMPDUMPFILE
     fi
 
     unset __deferred_compdefs

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -53,7 +53,7 @@ if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]];
 
         -antigen-lazyloader () {
             for command in ${(Mok)functions:#antigen*}; do
-                eval "$command () { echo 'from lazy load'; source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
+                eval "$command () { source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
             done
             unfunction -- '-antigen-lazyloader'
         }
@@ -237,8 +237,7 @@ fi
 # Set $_ANTIGEN_FORCE_RESET_COMPDUMP to true to do so
 -antigen-reset-compdump () {
     if [[ $_ANTIGEN_FORCE_RESET_COMPDUMP == true && -f $ANTIGEN_COMPDUMPFILE ]]; then
-        rm $ANTIGEN_COMPDUMPFILE 
-        rm $ANTIGEN_COMPDUMPFILE.zwc &> /dev/null
+        rm $ANTIGEN_COMPDUMPFILE
     fi
 }
 -antigen-resolve-bundle-url () {
@@ -1137,7 +1136,6 @@ zcache-done () {
         -zcache-antigen-update "$@"
         antigen-cache-reset
     }
-
     unset _ZCACHE_BUNDLES
 }
 

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -88,7 +88,7 @@ if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]];
         }
 
         # Disable antigen commands
-        local _commands=('use' 'bundle' 'bundles' 'init' 'theme' 'list' 'apply' 'cleanup' \
+        _commands=('use' 'bundle' 'bundles' 'init' 'theme' 'list' 'apply' 'cleanup' \
          'help' 'list' 'reset' 'restore' 'revert' 'snapshot' 'selfupdate' 'update' 'version')
         for command in $_commands; do
             eval "antigen-$command () {}"

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -903,7 +903,7 @@ _antigen () {
     local regexp='/\{$/,/^\}/!{
                /\$.?0/i\'$'\n''__ZCACHE_FILE_PATH="'$src'"
                s/\$(.?)0/\$\1__ZCACHE_FILE_PATH/'
-    
+
     if [[ "$btype" == "theme" ]]; then
         regexp+="
         s/^local //"
@@ -976,6 +976,7 @@ _antigen () {
     _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
     echo -E $_payload | sed 's/\\NL/\'$'\n/g' >! "$_ZCACHE_PAYLOAD_PATH"
+    zcompile "$_ZCACHE_PAYLOAD_PATH"
     echo "$_ZCACHE_BUNDLES" >! "$_ZCACHE_BUNDLES_PATH"
 }
 

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -7,7 +7,7 @@
 # Each line in this string has the following entries separated by a space
 # character.
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
-local _ANTIGEN_BUNDLE_RECORD=""
+#local _ANTIGEN_BUNDLE_RECORD=""
 local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}
@@ -25,7 +25,7 @@ fi
 
 # Used to defer compinit/compdef
 typeset -a __deferred_compdefs
-compdef () { __deferred_compdefs=($__deferred_compdefs "$*") } 
+compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
 
 # A syntax sugar to avoid the `-` when calling antigen commands. With this
 # function, you can write `antigen-bundle` as `antigen bundle` and so on.

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -15,16 +15,17 @@ local _ANTIGEN_INTERACTIVE=${_ANTIGEN_INTERACTIVE_MODE:-false}
 local _ANTIGEN_RESET_THEME_HOOKS=${_ANTIGEN_RESET_THEME_HOOKS:-true}
 local _ANTIGEN_AUTODETECT_CONFIG_CHANGES=${_ANTIGEN_AUTODETECT_CONFIG_CHANGES:-true}
 local _ANTIGEN_FORCE_RESET_COMPDUMP=${_ANTIGEN_FORCE_RESET_COMPDUMP:-true}
+local _ANTIGEN_FAST_BOOT_ENABLED=${_ANTIGEN_FAST_BOOT_ENABLED:-true}
 
 # Do not load anything if git is not available.
-if ! which git &> /dev/null; then
+if (( ! $+commands[git] )); then
     echo 'Antigen: Please install git to use Antigen.' >&2
     return 1
 fi
 
 # Used to defer compinit/compdef
 typeset -a __deferred_compdefs
-compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
+compdef () { __deferred_compdefs=($__deferred_compdefs "$*") } 
 
 # A syntax sugar to avoid the `-` when calling antigen commands. With this
 # function, you can write `antigen-bundle` as `antigen bundle` and so on.

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -7,7 +7,7 @@
 # Each line in this string has the following entries separated by a space
 # character.
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
-#local _ANTIGEN_BUNDLE_RECORD=""
+local _ANTIGEN_BUNDLE_RECORD=${_ANTIGEN_BUNDLE_RECORD:-""}
 local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}
@@ -37,7 +37,7 @@ antigen () {
     fi
     shift
 
-    if functions "antigen-$cmd" > /dev/null; then
+    if (( $+functions[antigen-$cmd] )); then
         "antigen-$cmd" "$@"
     else
         echo "Antigen: Unknown command: $cmd" >&2

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -8,7 +8,7 @@ if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]];
 
         -antigen-lazyloader () {
             for command in ${(Mok)functions:#antigen*}; do
-                eval "$command () { echo 'from lazy load'; source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
+                eval "$command () { source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
             done
             unfunction -- '-antigen-lazyloader'
         }

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -7,6 +7,12 @@ if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]];
         source "$_ZCACHE_PAYLOAD"
 
         -antigen-lazyloader () {
+            autoload -Uz compinit
+            if $_ANTIGEN_COMP_ENABLED; then
+                compinit -iC
+                compdef _antigen antigen
+            fi
+
             for command in ${(Mok)functions:#antigen*}; do
                 eval "$command () { source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
             done

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -3,28 +3,30 @@ _ZCACHE_PAYLOAD="${ADOTDIR:-$HOME/.antigen}/.cache/.zcache-payload"
 _ANTIGEN_COMPDUMPFILE=${ANTIGEN_COMPDUMPFILE:-$HOME/.zcompdump}
 
 if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]]; then
-    if [[ $_ZCACHE_CACHE_LOADED == false && -f "$_ZCACHE_PAYLOAD" ]]; then
+    if [[ $_ZCACHE_CACHE_LOADED != true && -f "$_ZCACHE_PAYLOAD" ]]; then
         source "$_ZCACHE_PAYLOAD"
-    
-        -antigen-selfsource () {
-            source "$_ANTIGEN_SOURCE"
-            
-            unfunction -- '-antigen-selfsource'
+
+        -antigen-lazyloader () {
+            for command in ${(Mok)functions:#antigen*}; do
+                eval "$command () { echo 'from lazy load'; source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
+            done
+            unfunction -- '-antigen-lazyloader'
         }
-        antigen-use () { }
-        antigen-theme () { }
-        antigen-bundle () { }
-        antigen-init () { }
+
+        # Disable antigen commands
+        for command in use bundle bundles init theme list apply cleanup help list reset restore revert snapshot selfupdate update version; do
+            eval "antigen-$command () {}"
+        done
+
         antigen () {
             if [[ "$1" == "apply" ]]; then
-                -antigen-selfsource
+                -antigen-lazyloader
             fi
         }
 
         antigen-apply () {
-            -antigen-selfsource
+            -antigen-lazyloader
         }
-
         return
     fi
 fi

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -43,7 +43,7 @@ if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]];
         }
 
         # Disable antigen commands
-        local _commands=('use' 'bundle' 'bundles' 'init' 'theme' 'list' 'apply' 'cleanup' \
+        _commands=('use' 'bundle' 'bundles' 'init' 'theme' 'list' 'apply' 'cleanup' \
          'help' 'list' 'reset' 'restore' 'revert' 'snapshot' 'selfupdate' 'update' 'version')
         for command in $_commands; do
             eval "antigen-$command () {}"

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -1,38 +1,65 @@
+# Used for lazy-loading.
 _ANTIGEN_SOURCE="$(cd "$(dirname "$0")" && pwd)/antigen.zsh"
+# Used to fastboot antigen
 _ZCACHE_PAYLOAD="${ADOTDIR:-$HOME/.antigen}/.cache/.zcache-payload"
-_ANTIGEN_COMPDUMPFILE=${ANTIGEN_COMPDUMPFILE:-$HOME/.zcompdump}
 
+# Use this functionallity only if both CACHE and FASTBOOT options are enabled.
 if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]]; then
+    
+    # If there is cache (zcache payload), and it wasn't loaded then procced.
+    
+    # The condition "$_ZCACHE_CACHE_LOADED != true" was crafted this way because
+    # $_ZCACHE_CACHE_LOADED variable is otherwise undefined, so it seems easier to
+    # check for a known value.
     if [[ $_ZCACHE_CACHE_LOADED != true && -f "$_ZCACHE_PAYLOAD" ]]; then
+
+        # Do load zcache payload, this has the following effects:
+        #   - _ANTIGEN_BUNDLE_RECORD is updated from cache
+        #   - _ZCACHE_CACHE_LOADED is set to TRUE
+        #   - _antigen is updated from cache
+        #   - fpath is updated from cache
         source "$_ZCACHE_PAYLOAD"
 
+        # Lazyload wrapper
         -antigen-lazyloader () {
+            # Be sure to have completions
             autoload -Uz compinit
             if $_ANTIGEN_COMP_ENABLED; then
                 compinit -iC
+                # At this point we got completions because antigen command exists
+                # and compdef does as well from zcache payload.
                 compdef _antigen antigen
             fi
 
+            # Hook antigen functions to lazy load antigen itself
             for command in ${(Mok)functions:#antigen*}; do
+                # Once any of the hooked functions are called and antigen is finally
+                # loaded what will happen is that antigen overwrittes the hooked functions
+                # so no other call to them will be executed, thus no need to
+                # 'unhook' or uninitialize them.
                 eval "$command () { source "$_ANTIGEN_SOURCE"; eval $command \$@ }"
             done
             unfunction -- '-antigen-lazyloader'
         }
 
         # Disable antigen commands
-        for command in use bundle bundles init theme list apply cleanup help list reset restore revert snapshot selfupdate update version; do
+        local _commands=('use' 'bundle' 'bundles' 'init' 'theme' 'list' 'apply' 'cleanup' \
+         'help' 'list' 'reset' 'restore' 'revert' 'snapshot' 'selfupdate' 'update' 'version')
+        for command in $_commands; do
             eval "antigen-$command () {}"
         done
 
+        # On antigen apply
         antigen () {
             if [[ "$1" == "apply" ]]; then
                 -antigen-lazyloader
             fi
         }
-
+        # On antigen-apply
         antigen-apply () {
             -antigen-lazyloader
         }
+
         return
     fi
 fi

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -1,0 +1,30 @@
+_ANTIGEN_SOURCE="$(cd "$(dirname "$0")" && pwd)/antigen.zsh"
+_ZCACHE_PAYLOAD="${ADOTDIR:-$HOME/.antigen}/.cache/.zcache-payload"
+_ANTIGEN_COMPDUMPFILE=${ANTIGEN_COMPDUMPFILE:-$HOME/.zcompdump}
+
+if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_FAST_BOOT_ENABLED == true ]]; then
+    if [[ $_ZCACHE_CACHE_LOADED == false && -f "$_ZCACHE_PAYLOAD" ]]; then
+        source "$_ZCACHE_PAYLOAD"
+    
+        -antigen-selfsource () {
+            source "$_ANTIGEN_SOURCE"
+            
+            unfunction -- '-antigen-selfsource'
+        }
+        antigen-use () { }
+        antigen-theme () { }
+        antigen-bundle () { }
+        antigen-init () { }
+        antigen () {
+            if [[ "$1" == "apply" ]]; then
+                -antigen-selfsource
+            fi
+        }
+
+        antigen-apply () {
+            -antigen-selfsource
+        }
+
+        return
+    fi
+fi

--- a/src/commands/apply.zsh
+++ b/src/commands/apply.zsh
@@ -17,14 +17,17 @@ antigen-apply () {
 
     # Load the compinit module. This will readefine the `compdef` function to
     # the one that actually initializes completions.
-    autoload -U compinit
-    compinit -i -d $ANTIGEN_COMPDUMPFILE
-
-    # Apply all `compinit`s that have been deferred.
-    local cdef
-    for cdef in "${__deferred_compdefs[@]}"; do
-        compdef "$cdef"
-    done
+    autoload -Uz compinit
+    compinit -iCd $ANTIGEN_COMPDUMPFILE
+    if [[ ! -f "$_ANTIGEN_COMPDUMPFILE.zwc" ]]; then
+        # Apply all `compinit`s that have been deferred.
+        local cdef
+        for cdef in "${__deferred_compdefs[@]}"; do
+            compdef "$cdef"
+        done
+        
+        zcompile $_ANTIGEN_COMPDUMPFILE
+    fi
 
     unset __deferred_compdefs
 

--- a/src/commands/apply.zsh
+++ b/src/commands/apply.zsh
@@ -19,14 +19,14 @@ antigen-apply () {
     # the one that actually initializes completions.
     autoload -Uz compinit
     compinit -iCd $ANTIGEN_COMPDUMPFILE
-    if [[ ! -f "$_ANTIGEN_COMPDUMPFILE.zwc" ]]; then
+    if [[ ! -f "$ANTIGEN_COMPDUMPFILE.zwc" ]]; then
         # Apply all `compinit`s that have been deferred.
         local cdef
         for cdef in "${__deferred_compdefs[@]}"; do
             compdef "$cdef"
         done
-        
-        zcompile $_ANTIGEN_COMPDUMPFILE
+
+        zcompile $ANTIGEN_COMPDUMPFILE
     fi
 
     unset __deferred_compdefs

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -66,7 +66,6 @@ zcache-done () {
         -zcache-antigen-update "$@"
         antigen-cache-reset
     }
-
     unset _ZCACHE_BUNDLES
 }
 

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -44,16 +44,16 @@ zcache-done () {
         return 1
     fi
     unset _ZCACHE_EXTENSION_ACTIVE
-    
+
     -zcache-unhook-antigen
-    
+
     # Avoids seg fault on zsh 4.3.5
     if [[ ${#_ZCACHE_BUNDLES} -gt 0 ]]; then
         if ! zcache-cache-exists || -zcache-cache-invalidated; then
             -zcache-generate-cache
             -antigen-reset-compdump
         fi
-        
+
         zcache-load-cache
     fi
 
@@ -66,7 +66,7 @@ zcache-done () {
         -zcache-antigen-update "$@"
         antigen-cache-reset
     }
-    
+
     unset _ZCACHE_BUNDLES
 }
 

--- a/src/ext/zcache/functions.zsh
+++ b/src/ext/zcache/functions.zsh
@@ -17,7 +17,7 @@
     local regexp='/\{$/,/^\}/!{
                /\$.?0/i\'$'\n''__ZCACHE_FILE_PATH="'$src'"
                s/\$(.?)0/\$\1__ZCACHE_FILE_PATH/'
-    
+
     if [[ "$btype" == "theme" ]]; then
         regexp+="
         s/^local //"
@@ -90,6 +90,7 @@
     _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
     echo -E $_payload | sed 's/\\NL/\'$'\n/g' >! "$_ZCACHE_PAYLOAD_PATH"
+    zcompile "$_ZCACHE_PAYLOAD_PATH"
     echo "$_ZCACHE_BUNDLES" >! "$_ZCACHE_BUNDLES_PATH"
 }
 

--- a/src/ext/zcache/functions.zsh
+++ b/src/ext/zcache/functions.zsh
@@ -80,7 +80,10 @@
             _extensions_paths+=($location)
         fi
     done
-
+    
+    _payload+="\NL"
+    _payload+="$(functions -- _antigen)"
+    _payload+="\NL"
     _payload+="fpath+=(${_extensions_paths[@]})\NL"
     _payload+="unset __ZCACHE_FILE_PATH\NL"
     # \NL (\n) prefix is for backward compatibility

--- a/src/helpers/reset-compdump.zsh
+++ b/src/helpers/reset-compdump.zsh
@@ -3,6 +3,7 @@
 # Set $_ANTIGEN_FORCE_RESET_COMPDUMP to true to do so
 -antigen-reset-compdump () {
     if [[ $_ANTIGEN_FORCE_RESET_COMPDUMP == true && -f $ANTIGEN_COMPDUMPFILE ]]; then
-        rm $ANTIGEN_COMPDUMPFILE
+        rm $ANTIGEN_COMPDUMPFILE 
+        rm $ANTIGEN_COMPDUMPFILE.zwc &> /dev/null
     fi
 }

--- a/src/helpers/reset-compdump.zsh
+++ b/src/helpers/reset-compdump.zsh
@@ -3,7 +3,6 @@
 # Set $_ANTIGEN_FORCE_RESET_COMPDUMP to true to do so
 -antigen-reset-compdump () {
     if [[ $_ANTIGEN_FORCE_RESET_COMPDUMP == true && -f $ANTIGEN_COMPDUMPFILE ]]; then
-        rm $ANTIGEN_COMPDUMPFILE 
-        rm $ANTIGEN_COMPDUMPFILE.zwc &> /dev/null
+        rm $ANTIGEN_COMPDUMPFILE
     fi
 }

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -21,7 +21,7 @@
     # Setup antigen's own completion.
     autoload -Uz compinit
     if $_ANTIGEN_COMP_ENABLED; then
-      compinit -C $ANTIGEN_COMPDUMPFILE
+      compinit -iC
       compdef _antigen antigen
     fi
 

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -21,11 +21,10 @@
     # Setup antigen's own completion.
     autoload -Uz compinit
     if $_ANTIGEN_COMP_ENABLED; then
-        compinit -C
-        compdef _antigen antigen
+      compinit -C $ANTIGEN_COMPDUMPFILE
+      compdef _antigen antigen
     fi
 
     # Remove private functions.
     unfunction -- -set-default
-
 }

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -8,6 +8,7 @@ export ADOTDIR="$PWD/dot-antigen"
 export _ANTIGEN_CACHE_ENABLED=true
 export _ANTIGEN_INTERACTIVE_MODE=true
 export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS=false
+export _ANTIGEN_BUNDLE_RECORD=""
 
 test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -53,13 +53,13 @@ List command should work as expected.
 
 Respect escape sequences.
 
-  $ cat $_ZCACHE_PAYLOAD_PATH | grep prompt
+  $ cat $_ZCACHE_PAYLOAD_PATH | grep 'alias prompt'
   alias prompt="\e]$ >\a\n"
 
 Cache is saved correctly.
 
   $ cat $_ZCACHE_PAYLOAD_PATH | wc -l
-  24
+  52
 
   $ cat $_ZCACHE_PAYLOAD_PATH | grep -Pzc 'hehe2"\nalias prompt'
   1

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -37,7 +37,7 @@ Should have listed bundles.
   2
 
   $ ls -A $_ZCACHE_PATH | wc -l
-  2
+  3
 
 Both bundles are cached.
 
@@ -105,7 +105,7 @@ Do not generate or load cache if there are no bundles.
 
   $ antigen reset &> /dev/null
   $ ls -A $_ZCACHE_PATH | wc -l
-  0
+  1
 
 Antigen cache-reset command deprecated.
 
@@ -119,4 +119,4 @@ Can clear cache correctly.
   Done. Please open a new shell to see the changes.
 
   $ ls -A $_ZCACHE_PATH | wc -l
-  0
+  1


### PR DESCRIPTION
- Load straight from cache
- Compiles compdump
- Hooks antigen functions

Reduced startup time from ~0.30s to ~0.15s

Added _ANTIGEN_FAST_BOOT_ENABLED env variable to enable or disable
this functionallity.

### TODO 
  - [x] Hook antigen-bundles
  - [x] Lazy load Antigen
  - [x] Compile zcache-payload
  - [x] Fix cache tests

### Comparative

Time expressed in seconds.

![screen shot 2016-10-19 at 3 00 45 pm](https://cloud.githubusercontent.com/assets/1857707/19531128/e93559ac-960c-11e6-8595-12def9c0cc13.png)

https://docs.google.com/spreadsheets/d/1ARbI5_1A6P5JjO2PHluIGJ8xM2Cdi7eHuROFvV8sleY/edit?usp=sharing