### PR TITLE
Support git shallow cloning for bundles

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -327,7 +327,7 @@ fi
     if [[ ! -d $clone_dir ]]; then
         install_or_update=true
         echo -n "Installing $(-antigen-bundle-short-name $url)... "
-        git clone --recursive "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
+        git clone $ANTIGEN_CLONE_OPTS "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
         success=$?
     elif $update; then
         local branch=master
@@ -344,7 +344,7 @@ fi
         --plugin-git pull origin $branch
         success=$?
         # Update submodules.
-        --plugin-git submodule update --recursive
+        --plugin-git submodule update $ANTIGEN_CLONE_OPTS
         # Get the new revision.
         local new_rev="$(--plugin-git rev-parse HEAD)"
     fi
@@ -395,8 +395,10 @@ fi
     if [[ ! -d $ADOTDIR ]]; then
         mkdir -p $ADOTDIR
     fi
-    -set-default _ANTIGEN_LOG_PATH "$ADOTDIR/antigen.log"
     -set-default ANTIGEN_COMPDUMPFILE "${ZDOTDIR:-$HOME}/.zcompdump"
+
+    -set-default _ANTIGEN_LOG_PATH "$ADOTDIR/antigen.log"
+    -set-default _ANTIGEN_CLONE_OPTS "--recursive --depth=1"
 
     # Setup antigen's own completion.
     autoload -Uz compinit

--- a/src/lib/ensure-repo.zsh
+++ b/src/lib/ensure-repo.zsh
@@ -33,7 +33,7 @@
     if [[ ! -d $clone_dir ]]; then
         install_or_update=true
         echo -n "Installing $(-antigen-bundle-short-name $url)... "
-        git clone --recursive "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
+        git clone $ANTIGEN_CLONE_OPTS "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
         success=$?
     elif $update; then
         local branch=master
@@ -50,7 +50,7 @@
         --plugin-git pull origin $branch
         success=$?
         # Update submodules.
-        --plugin-git submodule update --recursive
+        --plugin-git submodule update $ANTIGEN_CLONE_OPTS
         # Get the new revision.
         local new_rev="$(--plugin-git rev-parse HEAD)"
     fi

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -15,8 +15,10 @@
     if [[ ! -d $ADOTDIR ]]; then
         mkdir -p $ADOTDIR
     fi
-    -set-default _ANTIGEN_LOG_PATH "$ADOTDIR/antigen.log"
     -set-default ANTIGEN_COMPDUMPFILE "${ZDOTDIR:-$HOME}/.zcompdump"
+
+    -set-default _ANTIGEN_LOG_PATH "$ADOTDIR/antigen.log"
+    -set-default _ANTIGEN_CLONE_OPTS "--recursive --depth=1"
 
     # Setup antigen's own completion.
     autoload -Uz compinit


### PR DESCRIPTION
Added `_ANTIGEN_CLONE_OPTS` environment variable to be able to pass
options to git's `clone` and `submodule update` commands.

Default value is: `--recursive --depth=1`. `depth=1` effectively
creates a shallow clone.

## TODO

 - [x] Review behavior with `git 1.8`

Fixes #306 