### PR TITLE
Disable cache related commands with cache disabled

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1199,6 +1199,12 @@ antigen-init () {
 
 -antigen-interactive-mode # Updates _ANTIGEN_INTERACTIVE
 # Refusing to run in interactive mode
-if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_INTERACTIVE == false ]]; then
-    zcache-start
+if [[ $_ANTIGEN_CACHE_ENABLED == true ]]; then
+    if [[ $_ANTIGEN_INTERACTIVE == false ]]; then
+        zcache-start
+    fi
+else    
+    # Disable antigen-init and antigen-reset commands if cache is disabled
+    # and running in interactive modes
+    unfunction -- antigen-init antigen-reset antigen-cache-reset
 fi

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -164,6 +164,12 @@ antigen-init () {
 
 -antigen-interactive-mode # Updates _ANTIGEN_INTERACTIVE
 # Refusing to run in interactive mode
-if [[ $_ANTIGEN_CACHE_ENABLED == true && $_ANTIGEN_INTERACTIVE == false ]]; then
-    zcache-start
+if [[ $_ANTIGEN_CACHE_ENABLED == true ]]; then
+    if [[ $_ANTIGEN_INTERACTIVE == false ]]; then
+        zcache-start
+    fi
+else    
+    # Disable antigen-init and antigen-reset commands if cache is disabled
+    # and running in interactive modes
+    unfunction -- antigen-init antigen-reset antigen-cache-reset
 fi


### PR DESCRIPTION
Remove `antigen-init`, `antigen-reset` and `antigen-cache-reset` commands
when cache is disabled (ie `$_ANTIGEN_CACHE_ENABLED=false`).

Fixes #307