### PR TITLE
Antigen update command dynamically get default branch

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -264,7 +264,7 @@ antigen () {
         git clone --recursive "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
         success=$?
     elif $update; then
-        local branch=master
+        local branch=$(--plugin-git rev-parse --abbrev-ref HEAD)
         if [[ $url == *\|* ]]; then
             # Get the clone's branch
             branch="${url#*|}"
@@ -1099,7 +1099,7 @@ zcache-done () {
     eval "function -zcache-$(functions -- antigen-update)"
     antigen-update () {
         -zcache-antigen-update "$@"
-        antigen-cache-reset
+        antigen-reset
     }
     
     unset _ZCACHE_BUNDLES

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -64,7 +64,7 @@ zcache-done () {
     eval "function -zcache-$(functions -- antigen-update)"
     antigen-update () {
         -zcache-antigen-update "$@"
-        antigen-cache-reset
+        antigen-reset
     }
     
     unset _ZCACHE_BUNDLES

--- a/src/lib/ensure-repo.zsh
+++ b/src/lib/ensure-repo.zsh
@@ -36,7 +36,7 @@
         git clone --recursive "${url%|*}" "$clone_dir" &>> $_ANTIGEN_LOG_PATH
         success=$?
     elif $update; then
-        local branch=master
+        local branch=$(--plugin-git rev-parse --abbrev-ref HEAD)
         if [[ $url == *\|* ]]; then
             # Get the clone's branch
             branch="${url#*|}"


### PR DESCRIPTION
Determine default clone branch for bundles.
Removed call to `cache-reset` in `antigen-update`.

Fixes #304