### PR TITLE
Update command handles local clones

### DIFF
--- a/src/commands/purge.zsh
+++ b/src/commands/purge.zsh
@@ -9,8 +9,32 @@ antigen-purge () {
   local bundle=$1
   local force=$2
 
-  # Put local keyword/variable definition on top
-  # for zsh <= 5.0.0 otherwise will complain about it
+  if [[ $# -eq 0  ]]; then
+    echo "Antigen: Missing argument."
+    return 1
+  fi
+
+  if -antigen-purge-bundle $bundle $force; then
+    antigen-reset
+  else
+    return $?
+  fi
+  
+  return 0
+}
+
+# Remove a bundle from filesystem
+#
+# Usage
+#   antigen-purge example/bundle [--force]
+#
+# Returns
+#   Nothing. Removes bundle from filesystem.
+-antigen-purge-bundle () {
+  local bundle=$1
+  local force=$2
+  local clone_dir=""
+
   local record=""
   local url=""
   local make_local_clone=""
@@ -22,6 +46,12 @@ antigen-purge () {
 
   # local keyword doesn't work on zsh <= 5.0.0
   record=$(-antigen-find-record $bundle)
+  
+  if [[ ! -n "$record" ]]; then
+    echo "Bundle not found in record. Try 'antigen bundle $bundle' first."
+    return 1
+  fi
+
   url="$(echo "$record" | cut -d' ' -f1)"
   make_local_clone=$(echo "$record" | cut -d' ' -f4)
 
@@ -29,45 +59,14 @@ antigen-purge () {
     echo "Bundle has no local clone. Will not be removed."
     return 1
   fi
-  
-  if [[ -n "$url" ]]; then
-    if -antigen-purge-bundle $url $force; then
-      antigen-reset
-    fi
-  else
-    echo "Bundle not found in record. Try 'antigen bundle $bundle' first."
-    return 1
-  fi
-  
-  return 0
-}
-
-# Remove a bundle from filesystem
-#
-# Usage
-#   antigen-purge http://github.com/example/bundle [--force]
-#
-# Returns
-#   Nothing. Removes bundle from filesystem.
--antigen-purge-bundle () {
-  local url=$1
-  local force=$2
-  local clone_dir=""
-
-  if [[ $# -eq 0  ]]; then
-    echo "Antigen: Missing argument."
-    return 1
-  fi
 
   clone_dir=$(-antigen-get-clone-dir "$url")
-  if [[ $force == "--force" ]]; then
+  if [[ $force == "--force" ]] || read -q "?Remove '$clone_dir'? (y/n) "; then
+    # Need empty line after read -q
+    [[ ! -n $force ]] && echo "" || echo "Removing '$clone_dir'.";
     rm -rf "$clone_dir"
-    return 0
-  elif read -q "?Remove '$clone_dir'? (y/n) "; then
-    echo ""
-    rm -rf "$clone_dir"
-    return 0
-  else
-    return 1
+    return $?
   fi
+
+  return 1
 }

--- a/src/helpers/find-record.zsh
+++ b/src/helpers/find-record.zsh
@@ -7,12 +7,18 @@
 #   String if record is found
 -antigen-find-record () {
   local bundle=$1
+  local _IFS
+
   # Using typeset in order to support zsh <= 5.0.0
   typeset -a records
+  
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
 
-  local _IFS="$IFS"
+  _IFS="$IFS"
   IFS=$'\n'
-  records=(${(f)_ANTIGEN_BUNDLE_RECORD})
+  records=(${(@f)$(-antigen-echo-record)})
   IFS="$_IFS"
   
   echo "${records[(r)*$bundle*]}"

--- a/tests/list.t
+++ b/tests/list.t
@@ -32,3 +32,32 @@ List command supports short format flag.
   $ antigen-list --short
   */test-plugin (glob)
   */test-plugin2 (glob)
+
+Find bundle/record internal function.
+
+  $ -antigen-find-record
+  [1]
+
+  $ -antigen-find-record nonexisting
+  
+
+  $ -antigen-find-record test
+  *test-plugin* (glob)
+
+  $ -antigen-find-record test-plugin
+  *test-plugin* (glob)
+
+  $ -antigen-find-record test-plugin2
+  *test-plugin2* (glob)
+
+  $ -antigen-find-record plugin2
+  *test-plugin2* (glob)
+
+  $ -antigen-find-record list.t/test-plugin
+  *test-plugin* (glob)
+
+  $ -antigen-find-record list.t/test-plugin2
+  *test-plugin2* (glob)
+
+  $ -antigen-find-record list.t
+  *test-plugin* (glob)

--- a/tests/purge.t
+++ b/tests/purge.t
@@ -4,6 +4,7 @@ Purge command removes a bundle from filesystem.
   *test-plugin* (glob)
 
   $ antigen-purge test-plugin --force
+  Removing '*test-plugin'. (glob)
   Done. Please open a new shell to see the changes.
 
 Purge command without arguments returns an error message.


### PR DESCRIPTION
- `antigen-update` command rejects `--no-local-clone`
- `antigen-update` performs `antigen-reset` automatically
- Add tests for `-antigen-find-record` function

Fixes #352 