### PR TITLE
Prevent error when calling `--plugin-git`

### DIFF
--- a/src/lib/ensure-repo.zsh
+++ b/src/lib/ensure-repo.zsh
@@ -16,6 +16,9 @@
     local update=${2:-false}
     # Verbose output.
     local verbose=${3:-false}
+    
+    # Ensure log file exists
+    [ ! -e $_ANTIGEN_LOG_PATH ] && touch $_ANTIGEN_LOG_PATH
 
     shift $#
 


### PR DESCRIPTION
If log file doesnt exists, build fails with this error:
```
-antigen-ensure-repo:26: no such file or directory: /home/talma/.antigen/antigen.log
```
