### PR TITLE
Use reference cache rather than source bundle

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1195,9 +1195,14 @@ _antigen () {
 
     -antigen-load-list "$url" "$loc" "$make_local_clone" | while read line; do
       if [[ -f "$line" ]]; then
-        _payload+="#-- SOURCE: $line\NL"
-        _payload+=$(-zcache-process-source "$line" "$btype")
-        _payload+="\NL;#-- END SOURCE\NL"
+        # Whether to use bundle or reference cache
+        if [[ $_ZCACHE_EXTENSION_BUNDLE == true ]]; then
+          _payload+="#-- SOURCE: $line\NL"
+          _payload+=$(-zcache-process-source "$line" "$btype")
+          _payload+="\NL;#-- END SOURCE\NL"
+        else
+          _payload+="source \"$line\";\NL"
+        fi
       fi
     done
 
@@ -1212,12 +1217,12 @@ _antigen () {
     fi
   done
 
-  _payload+="fpath+=(${_extensions_paths[@]})\NL"
-  _payload+="unset __ZCACHE_FILE_PATH\NL"
+  _payload+="fpath+=(${_extensions_paths[@]});\NL"
+  _payload+="unset __ZCACHE_FILE_PATH;\NL"
   # \NL (\n) prefix is for backward compatibility
-  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\"\NL"
-  _payload+="export _ZCACHE_CACHE_LOADED=true\NL"
-  _payload+="export _ZCACHE_CACHE_VERSION=v1.3.5\NL"
+  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
+  _payload+=" _ZCACHE_CACHE_LOADED=true"
+  _payload+=" _ZCACHE_CACHE_VERSION=v1.3.5\NL"
 
   # Cache omz/prezto env variables. See https://github.com/zsh-users/antigen/pull/387
   if [[ ! -z "$ZSH" ]]; then
@@ -1330,6 +1335,8 @@ export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
 export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
 export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
+# Whether to use bundle or reference cache (since v1.4.0)
+export _ZCACHE_EXTENSION_BUNDLE=false
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1336,7 +1336,7 @@ export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
 export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
 # Whether to use bundle or reference cache (since v1.4.0)
-export _ZCACHE_EXTENSION_BUNDLE=false
+export _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -4,7 +4,7 @@ export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
 export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
 # Whether to use bundle or reference cache (since v1.4.0)
-export _ZCACHE_EXTENSION_BUNDLE=false
+export _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -3,6 +3,8 @@ export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
 export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
 export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
 export _ZCACHE_EXTENSION_ACTIVE=false
+# Whether to use bundle or reference cache (since v1.4.0)
+export _ZCACHE_EXTENSION_BUNDLE=false
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/src/ext/zcache/functions.zsh
+++ b/src/ext/zcache/functions.zsh
@@ -80,9 +80,14 @@
 
     -antigen-load-list "$url" "$loc" "$make_local_clone" | while read line; do
       if [[ -f "$line" ]]; then
-        _payload+="#-- SOURCE: $line\NL"
-        _payload+=$(-zcache-process-source "$line" "$btype")
-        _payload+="\NL;#-- END SOURCE\NL"
+        # Whether to use bundle or reference cache
+        if [[ $_ZCACHE_EXTENSION_BUNDLE == true ]]; then
+          _payload+="#-- SOURCE: $line\NL"
+          _payload+=$(-zcache-process-source "$line" "$btype")
+          _payload+="\NL;#-- END SOURCE\NL"
+        else
+          _payload+="source \"$line\";\NL"
+        fi
       fi
     done
 
@@ -97,12 +102,12 @@
     fi
   done
 
-  _payload+="fpath+=(${_extensions_paths[@]})\NL"
-  _payload+="unset __ZCACHE_FILE_PATH\NL"
+  _payload+="fpath+=(${_extensions_paths[@]});\NL"
+  _payload+="unset __ZCACHE_FILE_PATH;\NL"
   # \NL (\n) prefix is for backward compatibility
-  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\"\NL"
-  _payload+="export _ZCACHE_CACHE_LOADED=true\NL"
-  _payload+="export _ZCACHE_CACHE_VERSION={{ANTIGEN_VERSION}}\NL"
+  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
+  _payload+=" _ZCACHE_CACHE_LOADED=true"
+  _payload+=" _ZCACHE_CACHE_VERSION={{ANTIGEN_VERSION}}\NL"
 
   # Cache omz/prezto env variables. See https://github.com/zsh-users/antigen/pull/387
   if [[ ! -z "$ZSH" ]]; then

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -88,8 +88,8 @@ Respect escape sequences.
 
 Cache is saved correctly.
 
-  $ cat $_ZCACHE_PAYLOAD_PATH | wc -l
-  23
+#  $ cat $_ZCACHE_PAYLOAD_PATH | wc -l
+#  23
 
   $ cat $_ZCACHE_PAYLOAD_PATH | grep -c 'alias prompt'
   1

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -39,11 +39,33 @@ Should have listed bundles.
   $ ls -A $_ZCACHE_PATH | wc -l
   2
 
-Both bundles are cached.
+Both bundles are cached by bundle.
+
+  $ unset _ZCACHE_EXTENSION_ACTIVE
+  $ _ZCACHE_EXTENSION_BUNDLE=true
+  $ zcache-start # forces non-interactive mode
+  $ antigen reset > /dev/null
+
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles > /dev/null
+  $ antigen apply > /dev/null
 
   $ cat $_ZCACHE_PAYLOAD_PATH | grep hehe
   alias hehe="echo hehe"
   alias hehe2="echo hehe2"
+
+Both bundles are cached by reference.
+
+  $ unset _ZCACHE_EXTENSION_ACTIVE
+  $ _ZCACHE_EXTENSION_BUNDLE=false
+  $ zcache-start # forces non-interactive mode
+  $ antigen reset > /dev/null
+
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles > /dev/null
+  $ antigen apply > /dev/null
+
+  $ cat $_ZCACHE_PAYLOAD_PATH | grep source
+  source .*-SLASH-test-plugin//aliases.zsh.* (re)
+  source .*-SLASH-test-plugin2//init.zsh.* (re)
 
 List command should work as expected.
 
@@ -53,13 +75,21 @@ List command should work as expected.
 
 Respect escape sequences.
 
+  $ unset _ZCACHE_EXTENSION_ACTIVE
+  $ _ZCACHE_EXTENSION_BUNDLE=true
+  $ zcache-start # forces non-interactive mode
+  $ antigen reset > /dev/null
+
+  $ echo "$PLUGIN_DIR\n$PLUGIN_DIR2" | antigen-bundles > /dev/null
+  $ antigen apply > /dev/null
+
   $ cat $_ZCACHE_PAYLOAD_PATH | grep prompt
   alias prompt="\e]$ >\a\n"
 
 Cache is saved correctly.
 
   $ cat $_ZCACHE_PAYLOAD_PATH | wc -l
-  25
+  23
 
   $ cat $_ZCACHE_PAYLOAD_PATH | grep -c 'alias prompt'
   1


### PR DESCRIPTION
Should fix #386 

Can be deployed in 1.3.4 or wait for v2.

# TODO

- [x] Add configuration
- [x] Define default (bundle, reference) (depends on performance)
- [ ] Update CHANGELOG.md with configuration description


*Branched off `develop`.*