### PR TITLE
Disable OSX builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,32 +47,6 @@ matrix:
       language: python
       env: ZSH_BUILD_VERSION=zsh-4.3.5
 
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=master
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-5.3
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-5.2
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-5.1
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-5.0.0
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-4.3.17
-    - os: osx
-      language: generic
-      env: ZSH_BUILD_VERSION=zsh-4.3.11
-    # zsh 4.3.5 fails on OS X. See https://travis-ci.org/zsh-users/antigen/jobs/184819719
-      #- os: osx
-      #language: generic
-      #env: ZSH_BUILD_VERSION=zsh-4.3.5
-
 addons:
     apt:
         sources:


### PR DESCRIPTION
Remove OSX from Travis CI's build matrix configuration.

Fixes #403