### PR TITLE
antige-use command handle library url

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -414,7 +414,7 @@ Takes no further arguments.
 ### antigen use
 
 This command lets you load any (supported) zsh pre-packaged framework, like
-oh-my-zsh. Usage is
+oh-my-zsh, as well as any library from custom url. Usage is
 
     antigen use oh-my-zsh
 
@@ -466,6 +466,15 @@ Please note that Prezto support is new and experimental. If you find any bugs, p
 report over on github issues.
 Also note that due to how Prezto is implemented Antigen has to alter `ZDOTDIR`
 environment variable, which is restored immediately after `antigen apply` command.
+
+#### custom library
+
+Use
+
+    antigen use https://github.com/custom/lib.git
+
+in your `.zshrc`, before any `antigen bundle` declarations. It take all arguments
+`antigen-bundle` command does.
 
 ### antigen theme
 

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1019,6 +1019,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
+    export ANTIGEN_DEFAULT_REPO_URL=$1
     antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1018,11 +1018,14 @@ antigen-use () {
     -antigen-use-oh-my-zsh
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
+  elif [[ $1 != "" ]]; then
+    echo antigen-bundle $@
   else
-    echo 'Usage: antigen-use <library-name>' >&2
+    echo 'Usage: antigen-use <library-name|url>' >&2
     echo 'Where <library-name> is any one of the following:' >&2
     echo ' * oh-my-zsh' >&2
     echo ' * prezto' >&2
+    echo '<url> is the full url.' >&2
     return 1
   fi
 }

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1019,7 +1019,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
-    echo antigen-bundle $@
+    antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2
     echo 'Where <library-name> is any one of the following:' >&2

--- a/src/commands/use.zsh
+++ b/src/commands/use.zsh
@@ -4,6 +4,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
+    export ANTIGEN_DEFAULT_REPO_URL=$1
     antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2

--- a/src/commands/use.zsh
+++ b/src/commands/use.zsh
@@ -3,11 +3,14 @@ antigen-use () {
     -antigen-use-oh-my-zsh
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
+  elif [[ $1 != "" ]]; then
+    echo antigen-bundle $@
   else
-    echo 'Usage: antigen-use <library-name>' >&2
+    echo 'Usage: antigen-use <library-name|url>' >&2
     echo 'Where <library-name> is any one of the following:' >&2
     echo ' * oh-my-zsh' >&2
     echo ' * prezto' >&2
+    echo '<url> is the full url.' >&2
     return 1
   fi
 }

--- a/src/commands/use.zsh
+++ b/src/commands/use.zsh
@@ -4,7 +4,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
-    echo antigen-bundle $@
+    antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2
     echo 'Where <library-name> is any one of the following:' >&2

--- a/tests/use.t
+++ b/tests/use.t
@@ -1,12 +1,12 @@
 Use url library.
   $ antigen-bundle () { echo $@ }
   $ antigen-use https://github.com/zsh-users/prezto.git
-  antigen-bundle https://github.com/zsh-users/prezto.git
+  https://github.com/zsh-users/prezto.git
 
 Accept antigen-bundle semantics.
   $ antigen-bundle () { echo $@ }
   $ antigen-use https://github.com/zsh-users/prezto.git --loc=lib
-  antigen-bundle https://github.com/zsh-users/prezto.git --loc=lib
+  https://github.com/zsh-users/prezto.git --loc=lib
 
 Missing argument.
 

--- a/tests/use.t
+++ b/tests/use.t
@@ -1,19 +1,21 @@
-Use unknown library.
+Use url library.
+  $ antigen-bundle () { echo $@ }
+  $ antigen-use https://github.com/zsh-users/prezto.git
+  antigen-bundle https://github.com/zsh-users/prezto.git
 
-  $ antigen-use unknown
-  Usage: antigen-use <library-name>
-  Where <library-name> is any one of the following:
-   * oh-my-zsh
-   * prezto
-  [1]
+Accept antigen-bundle semantics.
+  $ antigen-bundle () { echo $@ }
+  $ antigen-use https://github.com/zsh-users/prezto.git --loc=lib
+  antigen-bundle https://github.com/zsh-users/prezto.git --loc=lib
 
 Missing argument.
 
   $ antigen-use
-  Usage: antigen-use <library-name>
+  Usage: antigen-use <library-name|url>
   Where <library-name> is any one of the following:
    * oh-my-zsh
    * prezto
+  <url> is the full url.
   [1]
 
 Mock out the library loading functions.

--- a/tests/use.t
+++ b/tests/use.t
@@ -2,6 +2,8 @@ Use url library.
   $ antigen-bundle () { echo $@ }
   $ antigen-use https://github.com/zsh-users/prezto.git
   https://github.com/zsh-users/prezto.git
+  $ echo $ANTIGEN_DEFAULT_REPO_URL
+  https://github.com/zsh-users/prezto.git
 
 Accept antigen-bundle semantics.
   $ antigen-bundle () { echo $@ }


### PR DESCRIPTION
`antigen-use` command now handles library's repository url. This makes easier to use a custom library, ex:

    antigen use https://github.com/zsh-users/prezto.git
    antigen use https://github.com/custom/library.git

`antigen-use` command for custom library url handles identical semantics as `antigen-bundle`.

## TODO

  - [x] Update README

Fixes #402 