### PR TITLE
Fix bundle cache vs reference breaking themes relying on locals

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -323,7 +323,7 @@ antigen () {
 
   if [[ "$clone_dir" =~ "\/.zprezto" ]]; then
     if [[ "$(cd $clone_dir && git config --get remote.origin.url)" != "$url" ]]; then
-      echo "Setting $(basename "$clone_dir") remote to $url"
+      echo "Setting $(basename "$clone_dir") remote to $url."
       --plugin-git remote set-url origin $url
     fi
   fi

--- a/src/ext/zcache/functions.zsh
+++ b/src/ext/zcache/functions.zsh
@@ -81,7 +81,9 @@
     -antigen-load-list "$url" "$loc" "$make_local_clone" | while read line; do
       if [[ -f "$line" ]]; then
         # Whether to use bundle or reference cache
-        if [[ $_ZCACHE_EXTENSION_BUNDLE == true ]]; then
+        # Force bundle cache for btype = theme, until PR 
+        # https://github.com/robbyrussell/oh-my-zsh/pull/3743 is merged.
+        if [[ $_ZCACHE_EXTENSION_BUNDLE == true || $btype == "theme" ]]; then
           _payload+="#-- SOURCE: $line\NL"
           _payload+=$(-zcache-process-source "$line" "$btype")
           _payload+="\NL;#-- END SOURCE\NL"

--- a/src/helpers/update-remote.zsh
+++ b/src/helpers/update-remote.zsh
@@ -4,7 +4,7 @@
 
   if [[ "$clone_dir" =~ "\/.zprezto" ]]; then
     if [[ "$(cd $clone_dir && git config --get remote.origin.url)" != "$url" ]]; then
-      echo "Setting $(basename "$clone_dir") remote to $url"
+      echo "Setting $(basename "$clone_dir") remote to $url."
       --plugin-git remote set-url origin $url
     fi
   fi


### PR DESCRIPTION
This fixes a regression on #122 introduced by #387 (reference cache vs bundle cache).
Using bundle cache for themes (`btype = theme`).

Fixes #418 