### PR TITLE
Clean up exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ cache:
 
 env:
   global:
-    - ANTIGEN=$TRAVIS_BUILD_DIR
-    - ADOTDIR=$TRAVIS_BUILD_DIR
     - ZSH_REMOTE_URL=https://github.com/zsh-users/zsh.git
     - BUILDS_PATH=$HOME/.zsh-builds
     - ZSH_SOURCE=$HOME/zsh

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -421,12 +421,12 @@ antigen () {
 }
 
 -antigen-env-setup () {
-  # Helper function: Same as `export $1=$2`, but will only happen if the name
+  # Helper function: Same as `$1=$2`, but will only happen if the name
   # specified by `$1` is not already set.
   -set-default () {
     local arg_name="$1"
     local arg_value="$2"
-    eval "test -z \"\$$arg_name\" && export $arg_name='$arg_value'"
+    eval "test -z \"\$$arg_name\" && $arg_name='$arg_value'"
   }
 
   # Pre-startup initializations.
@@ -551,10 +551,10 @@ antigen () {
 
 -antigen-use-oh-my-zsh () {
   if [[ -z "$ZSH" ]]; then
-    export ZSH="$(-antigen-get-clone-dir "$ANTIGEN_DEFAULT_REPO_URL")"
+    ZSH="$(-antigen-get-clone-dir "$ANTIGEN_DEFAULT_REPO_URL")"
   fi
   if [[ -z "$ZSH_CACHE_DIR" ]]; then
-    export ZSH_CACHE_DIR="$ZSH/cache/"
+    ZSH_CACHE_DIR="$ZSH/cache/"
   fi
   antigen-bundle --loc=lib
 }
@@ -564,7 +564,7 @@ antigen () {
   if (( _zdotdir_set )); then
     _old_zdotdir=$ZDOTDIR
   fi
-  export ZDOTDIR=$ADOTDIR/repos/
+  ZDOTDIR=$ADOTDIR/repos/
 
   antigen-bundle $ANTIGEN_PREZTO_REPO_URL
 }
@@ -606,17 +606,6 @@ antigen-apply () {
     unset _old_zdotdir
   fi
   unset _zdotdir_set
-}
-antigen-bundles () {
-  # Bulk add many bundles at one go. Empty lines and lines starting with a `#`
-  # are ignored. Everything else is given to `antigen-bundle` as is, no
-  # quoting rules applied.
-  local line
-  grep '^[[:space:]]*[^[:space:]#]' | while read line; do
-    # Using `eval` so that we can use the shell-style quoting in each line
-    # piped to `antigen-bundles`.
-    eval "antigen-bundle $line"
-  done
 }
 # Syntaxes
 #   antigen-bundle <url> [<loc>=/]
@@ -663,6 +652,17 @@ antigen-bundle () {
   fi
 }
 
+antigen-bundles () {
+  # Bulk add many bundles at one go. Empty lines and lines starting with a `#`
+  # are ignored. Everything else is given to `antigen-bundle` as is, no
+  # quoting rules applied.
+  local line
+  grep '^[[:space:]]*[^[:space:]#]' | while read line; do
+    # Using `eval` so that we can use the shell-style quoting in each line
+    # piped to `antigen-bundles`.
+    eval "antigen-bundle $line"
+  done
+}
 # Cleanup unused repositories.
 antigen-cleanup () {
   local force=false
@@ -1033,7 +1033,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
-    export ANTIGEN_DEFAULT_REPO_URL=$1
+    ANTIGEN_DEFAULT_REPO_URL=$1
     antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2
@@ -1240,18 +1240,18 @@ _antigen () {
   _payload+="fpath+=(${_extensions_paths[@]});\NL"
   _payload+="unset __ZCACHE_FILE_PATH;\NL"
   # \NL (\n) prefix is for backward compatibility
-  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
+  _payload+=" _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
   _payload+=" _ZCACHE_CACHE_LOADED=true"
   _payload+=" _ZCACHE_CACHE_VERSION=v1.4.1\NL"
 
   # Cache omz/prezto env variables. See https://github.com/zsh-users/antigen/pull/387
   if [[ ! -z "$ZSH" ]]; then
-    _payload+="export ZSH=\"$ZSH\"";
+    _payload+=" ZSH=\"$ZSH\"";
     _payload+=" ZSH_CACHE_DIR=\"$ZSH_CACHE_DIR\"\NL";
   fi
 
   if [[ ! -z "$ZDOTDIR" ]]; then
-    _payload+="export ZDOTDIR=\"$ADOTDIR/repos/\"\NL";
+    _payload+=" ZDOTDIR=\"$ADOTDIR/repos/\"\NL";
   fi
 
   _payload+="#-- END ZCACHE GENERATED FILE\NL"
@@ -1350,13 +1350,13 @@ _antigen () {
   [[ $_ANTIGEN_AUTODETECT_CONFIG_CHANGES == true && ! -f $_ZCACHE_BUNDLES_PATH || $(cat $_ZCACHE_BUNDLES_PATH) != "$_ZCACHE_BUNDLES" ]];
 }
 
-export _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
-export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
-export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
-export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
-export _ZCACHE_EXTENSION_ACTIVE=false
+local _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
+local _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
+local _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
+local _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
+local _ZCACHE_EXTENSION_ACTIVE=false
 # Whether to use bundle or reference cache (since v1.4.0)
-export _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
+local _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/src/commands/use.zsh
+++ b/src/commands/use.zsh
@@ -4,7 +4,7 @@ antigen-use () {
   elif [[ $1 == prezto ]]; then
     -antigen-use-prezto
   elif [[ $1 != "" ]]; then
-    export ANTIGEN_DEFAULT_REPO_URL=$1
+    ANTIGEN_DEFAULT_REPO_URL=$1
     antigen-bundle $@
   else
     echo 'Usage: antigen-use <library-name|url>' >&2

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -1,10 +1,10 @@
-export _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
-export _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
-export _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
-export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
-export _ZCACHE_EXTENSION_ACTIVE=false
+local _ZCACHE_PATH="${_ANTIGEN_CACHE_PATH:-$ADOTDIR/.cache}"
+local _ZCACHE_PAYLOAD_PATH="$_ZCACHE_PATH/.zcache-payload"
+local _ZCACHE_BUNDLES_PATH="$_ZCACHE_PATH/.zcache-bundles"
+local _ZCACHE_EXTENSION_CLEAN_FUNCTIONS="${_ZCACHE_EXTENSION_CLEAN_FUNCTIONS:-true}"
+local _ZCACHE_EXTENSION_ACTIVE=false
 # Whether to use bundle or reference cache (since v1.4.0)
-export _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
+local _ZCACHE_EXTENSION_BUNDLE=${_ZCACHE_EXTENSION_BUNDLE:-false}
 local -a _ZCACHE_BUNDLES
 
 # Starts zcache execution.

--- a/src/ext/zcache/functions.zsh
+++ b/src/ext/zcache/functions.zsh
@@ -107,18 +107,18 @@
   _payload+="fpath+=(${_extensions_paths[@]});\NL"
   _payload+="unset __ZCACHE_FILE_PATH;\NL"
   # \NL (\n) prefix is for backward compatibility
-  _payload+="export _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
+  _payload+=" _ANTIGEN_BUNDLE_RECORD=\"\NL${(j:\NL:)_bundles_meta}\""
   _payload+=" _ZCACHE_CACHE_LOADED=true"
   _payload+=" _ZCACHE_CACHE_VERSION={{ANTIGEN_VERSION}}\NL"
 
   # Cache omz/prezto env variables. See https://github.com/zsh-users/antigen/pull/387
   if [[ ! -z "$ZSH" ]]; then
-    _payload+="export ZSH=\"$ZSH\"";
+    _payload+=" ZSH=\"$ZSH\"";
     _payload+=" ZSH_CACHE_DIR=\"$ZSH_CACHE_DIR\"\NL";
   fi
 
   if [[ ! -z "$ZDOTDIR" ]]; then
-    _payload+="export ZDOTDIR=\"$ADOTDIR/repos/\"\NL";
+    _payload+=" ZDOTDIR=\"$ADOTDIR/repos/\"\NL";
   fi
 
   _payload+="#-- END ZCACHE GENERATED FILE\NL"

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -1,10 +1,10 @@
 -antigen-env-setup () {
-  # Helper function: Same as `export $1=$2`, but will only happen if the name
+  # Helper function: Same as `$1=$2`, but will only happen if the name
   # specified by `$1` is not already set.
   -set-default () {
     local arg_name="$1"
     local arg_value="$2"
-    eval "test -z \"\$$arg_name\" && export $arg_name='$arg_value'"
+    eval "test -z \"\$$arg_name\" && $arg_name='$arg_value'"
   }
 
   # Pre-startup initializations.

--- a/src/lib/use-oh-my-zsh.zsh
+++ b/src/lib/use-oh-my-zsh.zsh
@@ -1,9 +1,9 @@
 -antigen-use-oh-my-zsh () {
   if [[ -z "$ZSH" ]]; then
-    export ZSH="$(-antigen-get-clone-dir "$ANTIGEN_DEFAULT_REPO_URL")"
+    ZSH="$(-antigen-get-clone-dir "$ANTIGEN_DEFAULT_REPO_URL")"
   fi
   if [[ -z "$ZSH_CACHE_DIR" ]]; then
-    export ZSH_CACHE_DIR="$ZSH/cache/"
+    ZSH_CACHE_DIR="$ZSH/cache/"
   fi
   antigen-bundle --loc=lib
 }

--- a/src/lib/use-prezto.zsh
+++ b/src/lib/use-prezto.zsh
@@ -3,7 +3,7 @@
   if (( _zdotdir_set )); then
     _old_zdotdir=$ZDOTDIR
   fi
-  export ZDOTDIR=$ADOTDIR/repos/
+  ZDOTDIR=$ADOTDIR/repos/
 
   antigen-bundle $ANTIGEN_PREZTO_REPO_URL
 }

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -1,5 +1,11 @@
 # zshrc file written for antigen's tests. Might not be a good one for daily use.
 
+# Clean the environment from CI so that environment tests will pass.
+
+unset ZSH_REMOTE_URL
+unset ZSH_SOURCE
+unset ZSH_BUILD_VERSION
+
 # See cram's documentation for some of the variables used below.
 
 ADOTDIR="$PWD/dot-antigen"

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -2,12 +2,12 @@
 
 # See cram's documentation for some of the variables used below.
 
-export ADOTDIR="$PWD/dot-antigen"
+ADOTDIR="$PWD/dot-antigen"
 [[ ! -d "$ADOTDIR" ]] && mkdir -p "$ADOTDIR"
 
-export _ANTIGEN_CACHE_ENABLED=true
-export _ANTIGEN_INTERACTIVE_MODE=true
-export _ZCACHE_EXTENSION_CLEAN_FUNCTIONS=false
+_ANTIGEN_CACHE_ENABLED=true
+_ANTIGEN_INTERACTIVE_MODE=true
+_ZCACHE_EXTENSION_CLEAN_FUNCTIONS=false
 
 test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 
@@ -15,15 +15,15 @@ source "$TESTDIR/../antigen.zsh"
 
 # A test plugin repository to test out antigen with.
 
-export PLUGIN_DIR="$PWD/test-plugin"
+PLUGIN_DIR="$PWD/test-plugin"
 mkdir "$PLUGIN_DIR"
 
 # A wrapper function over `git` to work with the test plugin repo.
 alias pg='git --git-dir "$PLUGIN_DIR/.git" --work-tree "$PLUGIN_DIR"'
 
 echo 'alias hehe="echo hehe"' > "$PLUGIN_DIR"/aliases.zsh
-echo 'export PS1="prompt>"' > "$PLUGIN_DIR"/silly.zsh-theme
-echo 'export PS1=">"' > "$PLUGIN_DIR"/arrow.zsh-theme
+echo 'PS1="prompt>"' > "$PLUGIN_DIR"/silly.zsh-theme
+echo 'PS1=">"' > "$PLUGIN_DIR"/arrow.zsh-theme
 
 {
     pg init
@@ -33,7 +33,7 @@ echo 'export PS1=">"' > "$PLUGIN_DIR"/arrow.zsh-theme
 
 # Another test plugin.
 
-export PLUGIN_DIR2="$PWD/test-plugin2"
+PLUGIN_DIR2="$PWD/test-plugin2"
 mkdir "$PLUGIN_DIR2"
 
 # A wrapper function over `git` to work with the test plugin repo.

--- a/tests/bundles.t
+++ b/tests/bundles.t
@@ -9,6 +9,14 @@ Check if they are both applied.
   $ hehe2
   hehe2
 
+Should not leak Antigen or OMZ environment variables.
+
+  $ env | sed -e 's/\=.*//' | grep -i antigen | wc -l
+  0
+
+  $ env | sed -e 's/\=.*//' | grep -i zsh | wc -l
+  0
+
 Clean it all up.
 
   $ _ANTIGEN_BUNDLE_RECORD=""

--- a/tests/bundles.t
+++ b/tests/bundles.t
@@ -11,7 +11,7 @@ Check if they are both applied.
 
 Clean it all up.
 
-  $ export _ANTIGEN_BUNDLE_RECORD=""
+  $ _ANTIGEN_BUNDLE_RECORD=""
   $ antigen-cleanup --force &> /dev/null
 
 Specify with indentation.

--- a/tests/cache.t
+++ b/tests/cache.t
@@ -39,6 +39,14 @@ Should have listed bundles.
   $ ls -A $_ZCACHE_PATH | wc -l
   2
 
+Should not leak Antigen or OMZ environment variables.
+
+  $ env | sed -e 's/\=.*//' | grep -i antigen | wc -l
+  0
+
+  $ env | sed -e 's/\=.*//' | grep -i zsh | wc -l
+  0
+
 Both bundles are cached by bundle.
 
   $ unset _ZCACHE_EXTENSION_ACTIVE

--- a/tests/selfupdate.t
+++ b/tests/selfupdate.t
@@ -1,9 +1,9 @@
 Set environment variables for this test case
 
-  $ export TEST_DIR=$PWD
-  $ export TEST_HOST=$TEST_DIR/host
-  $ export TEST_NORMAL=$TEST_DIR/client
-  $ export TEST_SUBMODULE=$TEST_DIR/submodule
+  $ TEST_DIR=$PWD
+  $ TEST_HOST=$TEST_DIR/host
+  $ TEST_NORMAL=$TEST_DIR/client
+  $ TEST_SUBMODULE=$TEST_DIR/submodule
 
 Create fake host repository
 

--- a/tests/use.t
+++ b/tests/use.t
@@ -33,6 +33,14 @@ Use oh-my-zsh library.
   $ antigen-use oh-my-zsh
   Using oh-my-zsh.
 
+Should not leak Antigen or OMZ environment variables.
+
+  $ env | sed -e 's/\=.*//' | grep -i antigen | wc -l
+  0
+
+  $ env | sed -e 's/\=.*//' | grep -i zsh | wc -l
+  0
+
 Use prezto library.
 
   $ antigen-use prezto


### PR DESCRIPTION
Antigen leaks several variables into the environment of shell subprocesses. It seems to work fine without them. I thought about each of these, and could not identify reasons they would be necessary.