### PR TITLE
Missing input for `antigen-init` command

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1825,9 +1825,12 @@ antigen-init () {
   if [[ -f "$src" ]]; then
     source "$src"
     return
+  elif [[ -z "$1" ]]; then
+    echo "Antigen: missing input for 'antigen-init' command";
+    return
   fi
 
-  grep '^[[:space:]]*[^[:space:]#]' | while read line; do
+  grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do
     eval $line
   done
 }

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1823,14 +1823,18 @@ antigen-init () {
     return
   fi
 
-  if [[ -n "$src" && -f "$src" ]]; then
-    source "$src"
-    return
-  else
-    echo "Antigen: missing input for 'antigen-init' command or invalid argument provided.";
-    return 1
+  # If we're given an argument it should be a path to a file
+  if [[ -n "$src" ]]; then
+    if [[ -f "$src" ]]; then
+      source "$src"
+      return
+    else
+      echo "Antigen: invalid argument provided.";
+      return 1
+    fi
   fi
 
+  # Otherwise we expect it to be a heredoc
   grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do
     eval $line
   done

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1814,6 +1814,8 @@ antigen-cache-reset () {
 # Returns
 #   Nothing
 antigen-init () {
+  local src="$1"
+
   if zcache-cache-exists; then
     # Force cache to load - this does skip -zcache-cache-invalidate
     _ZCACHE_BUNDLES=$(cat $_ZCACHE_BUNDLES_PATH)
@@ -1821,13 +1823,12 @@ antigen-init () {
     return
   fi
 
-  local src="$1"
-  if [[ -f "$src" ]]; then
+  if [[ -n "$src" && -f "$src" ]]; then
     source "$src"
     return
-  elif [[ -z "$1" ]]; then
-    echo "Antigen: missing input for 'antigen-init' command";
-    return
+  else
+    echo "Antigen: missing input for 'antigen-init' command or invalid argument provided.";
+    return 1
   fi
 
   grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -149,6 +149,8 @@ antigen-cache-reset () {
 # Returns
 #   Nothing
 antigen-init () {
+  local src="$1"
+
   if zcache-cache-exists; then
     # Force cache to load - this does skip -zcache-cache-invalidate
     _ZCACHE_BUNDLES=$(cat $_ZCACHE_BUNDLES_PATH)
@@ -156,13 +158,12 @@ antigen-init () {
     return
   fi
 
-  local src="$1"
-  if [[ -f "$src" ]]; then
+  if [[ -n "$src" && -f "$src" ]]; then
     source "$src"
     return
-  elif [[ -z "$1" ]]; then
-    echo "Antigen: missing input for 'antigen-init' command";
-    return
+  else
+    echo "Antigen: missing input for 'antigen-init' command or invalid argument provided.";
+    return 1
   fi
 
   grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -158,14 +158,18 @@ antigen-init () {
     return
   fi
 
-  if [[ -n "$src" && -f "$src" ]]; then
-    source "$src"
-    return
-  else
-    echo "Antigen: missing input for 'antigen-init' command or invalid argument provided.";
-    return 1
+  # If we're given an argument it should be a path to a file
+  if [[ -n "$src" ]]; then
+    if [[ -f "$src" ]]; then
+      source "$src"
+      return
+    else
+      echo "Antigen: invalid argument provided.";
+      return 1
+    fi
   fi
 
+  # Otherwise we expect it to be a heredoc
   grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do
     eval $line
   done

--- a/src/ext/zcache.zsh
+++ b/src/ext/zcache.zsh
@@ -160,9 +160,12 @@ antigen-init () {
   if [[ -f "$src" ]]; then
     source "$src"
     return
+  elif [[ -z "$1" ]]; then
+    echo "Antigen: missing input for 'antigen-init' command";
+    return
   fi
 
-  grep '^[[:space:]]*[^[:space:]#]' | while read line; do
+  grep '^[[:space:]]*[^[:space:]#]' | while read -r line; do
     eval $line
   done
 }

--- a/tests/init.t
+++ b/tests/init.t
@@ -1,0 +1,34 @@
+Can source an dot-antigenrc file:
+
+  $ zcache-cache-exists () { false }
+  $ source () { echo $1 }
+  $ antigen-init $TESTDIR/.antigenrc
+  .*/.antigenrc (re)
+
+Returns error if non-existing file is given:
+
+  $ zcache-cache-exists () { false }
+  $ antigen-init /non-existing/file.zsh
+  Antigen: invalid argument provided.
+  [1]
+
+Can handle heredocs:
+
+  $ zcache-cache-exists () { false }
+  $ antigen () { echo $@ }
+  $ antigen-init <<EOB
+  > antigen use library
+  > antigen bundle bundle/name
+  > antigen apply
+  > EOB
+  use library
+  bundle bundle/name
+  apply
+
+Can load from cache, if available:
+
+  $ zcache-cache-exists () { true }
+  $ cat () { }
+  $ zcache-done () { echo Loaded cache. }
+  $ antigen-init /non-existing/file.zsh
+  Loaded cache.


### PR DESCRIPTION
Checks input for `antigen-init` command.


### TODO

  - [x] Add tests
  - [x] Return exit code 1 if no arguments

Fixes #440 