### PR TITLE
Bugfix/broken selfupdate

### DIFF
--- a/antigen.zsh
+++ b/antigen.zsh
@@ -1,3 +1,8 @@
-_ANTIGEN_INSTALL_DIR=${0:A:h}
+autoload -U is-at-least;
+if is-at-least 4.3.7; then
+  _ANTIGEN_INSTALL_DIR=${0:A:h}
+else
+  _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source $_ANTIGEN_INSTALL_DIR/bin/antigen.zsh
 

--- a/antigen.zsh
+++ b/antigen.zsh
@@ -1,1 +1,3 @@
-bin/antigen.zsh
+_ANTIGEN_INSTALL_DIR=${0:A:h}
+source $_ANTIGEN_INSTALL_DIR/bin/antigen.zsh
+

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -12,10 +12,12 @@ autoload -U is-at-least;
 # character.
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
 local _ANTIGEN_BUNDLE_RECORD=${_ANTIGEN_BUNDLE_RECORD:-""}
-if is-at-least 4.3.7; then
-  local _ANTIGEN_INSTALL_DIR=${0:A:h:h}
-else
-  local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -z "$_ANTIGEN_INSTALL_DIR" ]]; then
+  if is-at-least 4.3.7; then
+    local _ANTIGEN_INSTALL_DIR=${0:A:h}
+  else
+    local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+  fi
 fi
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -9,10 +9,12 @@ autoload -U is-at-least;
 # character.
 # <repo-url>, <plugin-location>, <bundle-type>, <has-local-clone>
 local _ANTIGEN_BUNDLE_RECORD=${_ANTIGEN_BUNDLE_RECORD:-""}
-if is-at-least 4.3.7; then
-  local _ANTIGEN_INSTALL_DIR=${0:A:h:h}
-else
-  local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -z "$_ANTIGEN_INSTALL_DIR" ]]; then
+  if is-at-least 4.3.7; then
+    local _ANTIGEN_INSTALL_DIR=${0:A:h}
+  else
+    local _ANTIGEN_INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+  fi
 fi
 local _ANTIGEN_CACHE_ENABLED=${_ANTIGEN_CACHE_ENABLED:-true}
 local _ANTIGEN_COMP_ENABLED=${_ANTIGEN_COMP_ENABLED:-true}


### PR DESCRIPTION
I believe the only gotcha is if you symlink to `bin/antigen.zsh` rather than `antigen.zsh` it'll report `bin` as install path.

Should fix #438 