### PR TITLE
`antigen-list` command shows loc information

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -383,7 +383,7 @@ this includes any bundles installed on-the-fly.
 With `--long` flag it gives out five entries per line of output,
 denoting the following fields of each bundle.
 
-    <repo-url> <loc> <btype> <has-local-clone?> <branch> @ <branch|tag|ref>
+    <repo-url> <loc> <btype> <has-local-clone?> <branch>
 
 The `btype` field is an internal detail, that specifies if the bundle is a
 `plugin` or a `theme`.

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -131,19 +131,21 @@ antigen () {
   for record in ${(@f)_ANTIGEN_BUNDLE_RECORD}; do
     url="$(echo "$record" | cut -d' ' -f1)"
     bundle_name=$(-antigen-bundle-short-name $url)
-    bundle_entry=$(-antigen-find-record $url)
-    
-    revision=$(-antigen-bundle-rev $url)
-    
+
     case "$mode" in
         --short)
+          revision=$(-antigen-bundle-rev $url)
+          loc="$(echo "$record" | cut -d' ' -f2)"
+          if [[ $loc != '/' ]]; then
+            bundle_name="$bundle_name ~ $loc"
+          fi
           echo "$bundle_name @ $revision"
         ;;
         --simple)
           echo "$bundle_name"
         ;;
         --long)
-          echo "$record @ $revision"
+          echo "$record"
         ;;
      esac
   done

--- a/src/helpers/get-bundles.zsh
+++ b/src/helpers/get-bundles.zsh
@@ -16,19 +16,21 @@
   for record in ${(@f)_ANTIGEN_BUNDLE_RECORD}; do
     url="$(echo "$record" | cut -d' ' -f1)"
     bundle_name=$(-antigen-bundle-short-name $url)
-    bundle_entry=$(-antigen-find-record $url)
-    
-    revision=$(-antigen-bundle-rev $url)
-    
+
     case "$mode" in
         --short)
+          revision=$(-antigen-bundle-rev $url)
+          loc="$(echo "$record" | cut -d' ' -f2)"
+          if [[ $loc != '/' ]]; then
+            bundle_name="$bundle_name ~ $loc"
+          fi
           echo "$bundle_name @ $revision"
         ;;
         --simple)
           echo "$bundle_name"
         ;;
         --long)
-          echo "$record @ $revision"
+          echo "$record"
         ;;
      esac
   done

--- a/tests/list.t
+++ b/tests/list.t
@@ -34,8 +34,8 @@ List command supports short format flag.
   .*/test-plugin2 @ master (re)
 
   $ antigen-list --long
-  .*/test-plugin / plugin true @ master (re)
-  .*/test-plugin2 / plugin true @ master (re)
+  .*/test-plugin / plugin true (re)
+  .*/test-plugin2 / plugin true (re)
 
 Can display feature branches.
 
@@ -48,8 +48,8 @@ Can display feature branches.
   .*/test-plugin2 @ .* (re)
 
   $ antigen-list --long
-  .*/test-plugin / plugin true @ master (re)
-  .*/test-plugin2 / plugin true @ .* (re)
+  .*/test-plugin / plugin true (re)
+  .*/test-plugin2 / plugin true (re)
 
 Find bundle/record internal function.
 


### PR DESCRIPTION
```
robbyrussell/oh-my-zsh @ master # for bundle git
robbyrussell/oh-my-zsh @ master # for theme pure
```
Should be displayed this way:

```
robbyrussell/oh-my-zsh ~ plugins/git @ master
robbyrussell/oh-my-zsh ~ themes/pure @ master
```

Another example:

```
robbyrussell/oh-my-zsh ~ plugins/per-directory-history @ master # for bundle plugins/per-directory-history
```
