### PR TITLE
Add more comprehensive help text.

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -975,13 +975,30 @@ antigen-cleanup () {
 }
 
 antigen-help () {
-  cat <<EOF
-Antigen is a plugin management system for zsh. It makes it easy to grab awesome
-shell scripts and utilities, put up on github. For further details and complete
-documentation, visit the project's page at 'http://antigen.sharats.me'.
-
-EOF
   antigen-version
+
+  cat <<EOF
+
+Antigen is a plugin management system for zsh. It makes it easy to grab awesome
+shell scripts and utilities, put up on Github.
+
+Usage: antigen <command> [args]
+
+Commands:
+  cache-gen    Generate Antigen's cache with currently loaded bundles.
+  init         Use caching to quickly load bundles.
+  update       Update plugins.
+  revert       *Experimental* Revert plugins to their state prior to the last
+               time 'antigen update' was run.
+  list         List currently loaded plugins.
+  cleanup      Remove clones of repos not used by any loaded plugins.
+  purge        Remove a bundle from the filesystem.
+  reset        Clean the generated cache.
+  use          Load a supported zsh pre-packaged framework.
+
+For further details and complete documentation, visit the project's page at
+'http://antigen.sharats.me'.
+EOF
 }
 # Antigen command to load antigen configuration
 #

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -985,6 +985,8 @@ shell scripts and utilities, put up on Github.
 Usage: antigen <command> [args]
 
 Commands:
+  apply        Must be called in the zshrc after all calls to 'antigen bundle'.
+  bundle       Install and load a plugin.
   cache-gen    Generate Antigen's cache with currently loaded bundles.
   init         Use caching to quickly load bundles.
   update       Update plugins.
@@ -994,6 +996,7 @@ Commands:
   cleanup      Remove clones of repos not used by any loaded plugins.
   purge        Remove a bundle from the filesystem.
   reset        Clean the generated cache.
+  selfupdate   Update antigen.
   use          Load a supported zsh pre-packaged framework.
 
 For further details and complete documentation, visit the project's page at

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -988,18 +988,18 @@ Commands:
   apply        Must be called in the zshrc after all calls to 'antigen bundle'.
   bundle       Install and load a plugin.
   cache-gen    Generate Antigen's cache with currently loaded bundles.
-  init         Use caching to quickly load bundles.
-  update       Update plugins.
-  revert       Revert plugins to their state prior to the last time 'antigen
-               update' was run.
-  list         List currently loaded plugins.
   cleanup      Remove clones of repos not used by any loaded plugins.
+  init         Use caching to quickly load bundles.
+  list         List currently loaded plugins.
   purge        Remove a bundle from the filesystem.
   reset        Clean the generated cache.
   restore      Restore plugin state from a snapshot file.
+  revert       Revert plugins to their state prior to the last time 'antigen
+               update' was run.
   selfupdate   Update antigen.
   snapshot     Create a snapshot of all active plugin repos and save it to a
                snapshot file.
+  update       Update plugins.
   use          Load a supported zsh pre-packaged framework.
 
 For further details and complete documentation, visit the project's page at

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -990,13 +990,16 @@ Commands:
   cache-gen    Generate Antigen's cache with currently loaded bundles.
   init         Use caching to quickly load bundles.
   update       Update plugins.
-  revert       *Experimental* Revert plugins to their state prior to the last
-               time 'antigen update' was run.
+  revert       Revert plugins to their state prior to the last time 'antigen
+               update' was run.
   list         List currently loaded plugins.
   cleanup      Remove clones of repos not used by any loaded plugins.
   purge        Remove a bundle from the filesystem.
   reset        Clean the generated cache.
+  restore      Restore plugin state from a snapshot file.
   selfupdate   Update antigen.
+  snapshot     Create a snapshot of all active plugin repos and save it to a
+               snapshot file.
   use          Load a supported zsh pre-packaged framework.
 
 For further details and complete documentation, visit the project's page at


### PR DESCRIPTION
This was a pretty trivial change so I thought I'd just make a PR to see if there was interest in this. I augmented the help text to be a little more comprehensive, such that it now includes the list of supported commands and descriptions of each.

Old behaviour:
```
> antigen help
Antigen is a plugin management system for zsh. It makes it easy to grab awesome
shell scripts and utilities, put up on github. For further details and complete
documentation, visit the project's page at 'http://antigen.sharats.me'.

Antigen v1.4.1
```

New behaviour:
```
> antigen help
Antigen v1.4.1

Antigen is a plugin management system for zsh. It makes it easy to grab awesome
shell scripts and utilities, put up on Github.

Usage: antigen <command> [args]

Commands:
  apply        Must be called in the zshrc after all calls to 'antigen bundle'.
  bundle       Install and load a plugin.
  cache-gen    Generate Antigen's cache with currently loaded bundles.
  cleanup      Remove clones of repos not used by any loaded plugins.
  init         Use caching to quickly load bundles.
  list         List currently loaded plugins.
  purge        Remove a bundle from the filesystem.
  reset        Clean the generated cache.
  restore      Restore plugin state from a snapshot file.
  revert       Revert plugins to their state prior to the last time 'antigen
               update' was run.
  selfupdate   Update antigen.
  snapshot     Create a snapshot of all active plugin repos and save it to a
               snapshot file.
  update       Update plugins.
  use          Load a supported zsh pre-packaged framework.

For further details and complete documentation, visit the project's page at
'http://antigen.sharats.me'.
```

Thoughts?