### PR TITLE
Fix overwriting of ZDOTDIR

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -868,9 +868,7 @@ compdef () {}\NL"
   if [[ -n "$ZSH" ]]; then
     _payload+="ZSH=\"$ZSH\" ZSH_CACHE_DIR=\"$ZSH_CACHE_DIR\"\NL";
   fi
-  if [[ -n "$ZDOTDIR" ]]; then
-    _payload+="ZDOTDIR=\"$ANTIGEN_BUNDLES\"\NL";
-  fi
+
   _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
   echo -E $_payload | sed 's/\\NL/\'$'\n/g' >! "$ANTIGEN_CACHE"

--- a/src/lib/zcache.zsh
+++ b/src/lib/zcache.zsh
@@ -135,9 +135,7 @@ compdef () {}\NL"
   if [[ -n "$ZSH" ]]; then
     _payload+="ZSH=\"$ZSH\" ZSH_CACHE_DIR=\"$ZSH_CACHE_DIR\"\NL";
   fi
-  if [[ -n "$ZDOTDIR" ]]; then
-    _payload+="ZDOTDIR=\"$ANTIGEN_BUNDLES\"\NL";
-  fi
+
   _payload+="#-- END ZCACHE GENERATED FILE\NL"
 
   echo -E $_payload | sed 's/\\NL/\'$'\n/g' >! "$ANTIGEN_CACHE"


### PR DESCRIPTION
As reported on gitter. `ZDOTDIR` was being overwrote by zcache lib code.