### PR TITLE
Remove possibly destructive command on broken tests

### DIFF
--- a/tests/ensure-repo.t
+++ b/tests/ensure-repo.t
@@ -44,7 +44,7 @@ Effectively update a repository already cloned:
 
 Clone especific branch if required:
 
-  $ rm -r $ANTIGEN_BUNDLES/*
+  $ rm -r $ANTIGEN_BUNDLES
   $ -antigen-ensure-repo "$REPO_URL|v5.0"
   Installing user/repo@v5.0... 
   git clone .* --branch v5.0 -- https://github.com/user/repo.git .*user/repo-v5.0 (re)


### PR DESCRIPTION
Remove possibly destructive command if antigen fails to load on a test (cram) run due to undefined variable.