### PR TITLE
Clean up globally defined variables

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1287,15 +1287,15 @@ antigen-snapshot () {
   # The snapshot content lines are pairs of repo-url and git version hash, in
   # the form:
   #   <version-hash> <repo-url>
-  local snapshot_content="$(
-    -antigen-echo-record |
-    awk '$4 == "true" {print $1}' |
-    sort -u |
-    while read url; do
-      local dir="$(-antigen-get-clone-dir "$url")"
-      local version_hash="$(cd "$dir" && git rev-parse HEAD)"
-      echo "$version_hash $url"
-    done)"
+  local urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
+  local url dir version_hash snapshot_content
+  local -a bundles
+  for url in ${(f)urls}; do
+    dir="$(-antigen-get-clone-dir "$url")"
+    version_hash="$(cd "$dir" && git rev-parse HEAD)"
+    bundles+=("$version_hash $url");
+  done
+  snapshot_content=${(j:\n:)bundles}
 
   {
     # The first line in the snapshot file is for metadata, in the form:
@@ -1320,7 +1320,6 @@ antigen-snapshot () {
 
   } > "$snapshot_file"
 }
-
 # Loads a given theme.
 #
 # Shares the same syntax as antigen-bundle command.

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1283,13 +1283,13 @@ antigen-selfupdate () {
 }
 antigen-snapshot () {
   local snapshot_file="${1:-antigen-shapshot}"
+  local urls url dir version_hash snapshot_content
+  local -a bundles
 
   # The snapshot content lines are pairs of repo-url and git version hash, in
   # the form:
   #   <version-hash> <repo-url>
-  local urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
-  local url dir version_hash snapshot_content
-  local -a bundles
+  urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
   for url in ${(f)urls}; do
     dir="$(-antigen-get-clone-dir "$url")"
     version_hash="$(cd "$dir" && git rev-parse HEAD)"

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1372,7 +1372,9 @@ antigen-theme () {
 
   # Clear out prompts
   PROMPT=""
-  RPROMPT=""
+  if [[ -n $RPROMPT ]]; then
+    RPROMPT=""
+  fi
 
   for hook in chpwd precmd preexec periodic; do
     add-zsh-hook -D "${hook}" "prompt_*"

--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -23,7 +23,7 @@
 # Returns
 #   Nothing
 antigen-init () {
-  local src="$1"
+  local src="$1" line
 
   # If we're given an argument it should be a path to a file
   if [[ -n "$src" ]]; then
@@ -41,4 +41,3 @@ antigen-init () {
     eval $line
   done
 }
-

--- a/src/commands/restore.zsh
+++ b/src/commands/restore.zsh
@@ -1,4 +1,5 @@
 antigen-restore () {
+  local line
   if [[ $# == 0 ]]; then
     echo 'Please provide a snapshot file to restore from.' >&2
     return 1
@@ -28,4 +29,3 @@ antigen-restore () {
   echo ' done.'
   echo 'Please open a new shell to get the restored changes.'
 }
-

--- a/src/commands/revert.zsh
+++ b/src/commands/revert.zsh
@@ -1,5 +1,6 @@
 # Reads $ADORDIR/revert-info and restores bundles' revision
 antigen-revert () {
+  local line
   if [[ -f $ADOTDIR/revert-info ]]; then
     cat $ADOTDIR/revert-info | sed -n '1!p' | while read line; do
       local dir="$(echo "$line" | cut -d: -f1)"
@@ -15,4 +16,3 @@ antigen-revert () {
     return 1
   fi
 }
-

--- a/src/commands/snapshot.zsh
+++ b/src/commands/snapshot.zsh
@@ -1,12 +1,12 @@
 antigen-snapshot () {
   local snapshot_file="${1:-antigen-shapshot}"
+  local urls url dir version_hash snapshot_content
+  local -a bundles
 
   # The snapshot content lines are pairs of repo-url and git version hash, in
   # the form:
   #   <version-hash> <repo-url>
-  local urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
-  local url dir version_hash snapshot_content
-  local -a bundles
+  urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
   for url in ${(f)urls}; do
     dir="$(-antigen-get-clone-dir "$url")"
     version_hash="$(cd "$dir" && git rev-parse HEAD)"

--- a/src/commands/snapshot.zsh
+++ b/src/commands/snapshot.zsh
@@ -4,15 +4,15 @@ antigen-snapshot () {
   # The snapshot content lines are pairs of repo-url and git version hash, in
   # the form:
   #   <version-hash> <repo-url>
-  local snapshot_content="$(
-    -antigen-echo-record |
-    awk '$4 == "true" {print $1}' |
-    sort -u |
-    while read url; do
-      local dir="$(-antigen-get-clone-dir "$url")"
-      local version_hash="$(cd "$dir" && git rev-parse HEAD)"
-      echo "$version_hash $url"
-    done)"
+  local urls=$(-antigen-echo-record | awk '$4 == "true" {print $1}' | sort -u)
+  local url dir version_hash snapshot_content
+  local -a bundles
+  for url in ${(f)urls}; do
+    dir="$(-antigen-get-clone-dir "$url")"
+    version_hash="$(cd "$dir" && git rev-parse HEAD)"
+    bundles+=("$version_hash $url");
+  done
+  snapshot_content=${(j:\n:)bundles}
 
   {
     # The first line in the snapshot file is for metadata, in the form:
@@ -37,4 +37,3 @@ antigen-snapshot () {
 
   } > "$snapshot_file"
 }
-

--- a/src/commands/theme.zsh
+++ b/src/commands/theme.zsh
@@ -8,8 +8,8 @@
 # Returns
 #   0 if everything was succesfully
 antigen-theme () {
-  local record
-  local result=0
+  local record result=0
+  local match mbegin mend MATCH MBEGIN MEND
 
   -antigen-theme-reset-hooks
 
@@ -59,4 +59,3 @@ antigen-theme () {
     add-zsh-hook -d "${hook}" "vcs_info"
   done
 }
-

--- a/src/commands/theme.zsh
+++ b/src/commands/theme.zsh
@@ -50,7 +50,9 @@ antigen-theme () {
 
   # Clear out prompts
   PROMPT=""
-  RPROMPT=""
+  if [[ -n $RPROMPT ]]; then
+    RPROMPT=""
+  fi
 
   for hook in chpwd precmd preexec periodic; do
     add-zsh-hook -D "${hook}" "prompt_*"

--- a/src/commands/update.zsh
+++ b/src/commands/update.zsh
@@ -6,7 +6,7 @@
 # Returns
 #    Nothing. Performs a `git pull`.
 antigen-update () {
-  local bundle=$1
+  local bundle=$1 url
 
   # Clear log
   :> $ANTIGEN_LOG

--- a/src/helpers/bundle-short-name.zsh
+++ b/src/helpers/bundle-short-name.zsh
@@ -5,14 +5,14 @@
 -antigen-bundle-short-name () {
   local bundle_name="${1%|*}"
   local bundle_branch="$2"
+  local match mbegin mend MATCH MBEGIN MEND
 
   [[ "$bundle_name" =~ '.*/(.*/.*).*$' ]] && bundle_name=$match[1]
   bundle_name="${bundle_name%.git*}"
-  
+
   if [[ -n $bundle_branch ]]; then
     bundle_name="$bundle_name@$bundle_branch"
   fi
 
   echo $bundle_name
 }
-

--- a/src/helpers/get-bundles.zsh
+++ b/src/helpers/get-bundles.zsh
@@ -7,6 +7,7 @@
 #   List of bundles installed
 -antigen-get-bundles () {
   local mode revision url bundle_name bundle_entry loc no_local_clone
+  local record bundle make_local_clone
   mode=${1:-"--short"}
 
   for record in $_ANTIGEN_BUNDLE_RECORD; do

--- a/src/helpers/get-clone-dir.zsh
+++ b/src/helpers/get-clone-dir.zsh
@@ -5,7 +5,7 @@
 -antigen-get-clone-dir () {
   local bundle="$1"
   local url="${bundle%|*}"
-  local branch
+  local branch match mbegin mend MATCH MBEGIN MEND
   [[ "$bundle" =~ "\|" ]] && branch="${bundle#*|}"
 
   # Takes a repo url and mangles it, giving the path that this url will be

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -4,7 +4,7 @@
   -set-default () {
     local arg_name="$1"
     local arg_value="$2"
-    eval "test -z \"\$$arg_name\" && $arg_name='$arg_value'"
+    eval "test -z \"\$$arg_name\" && typeset -g $arg_name='$arg_value'"
   }
 
   typeset -gU fpath path

--- a/src/lib/load.zsh
+++ b/src/lib/load.zsh
@@ -8,11 +8,8 @@
 # Returns
 #   Integer. 0 if success 1 if an error ocurred.
 -antigen-load () {
-  local url="$1"
-  local loc="$2"
-  local make_local_clone="$3"
-  local btype="$4"
-  local src
+  local url="$1" loc="$2" make_local_clone="$3" btype="$4"
+  local src line
 
   local location="$url"
   if $make_local_clone; then

--- a/src/lib/parse-args.zsh
+++ b/src/lib/parse-args.zsh
@@ -1,7 +1,6 @@
 -antigen-parse-args () {
-  local key
-  local value
-  local index=0
+  local argkey key value index=0
+  local match mbegin mend MATCH MBEGIN MEND
 
   while [[ $# -gt 0 ]]; do
     argkey="${1%\=*}"
@@ -53,4 +52,3 @@
     shift
   done
 }
-

--- a/src/lib/revert-info.zsh
+++ b/src/lib/revert-info.zsh
@@ -8,6 +8,7 @@
 # Returns
 #    Nothing. Generates/updates $ADOTDIR/revert-info.
 -antigen-revert-info() {
+  local url
   # Update your bundles, i.e., `git pull` in all the plugin repos.
   date >! $ADOTDIR/revert-info
 
@@ -20,4 +21,3 @@
     fi
   done
 }
-

--- a/src/lib/use-oh-my-zsh.zsh
+++ b/src/lib/use-oh-my-zsh.zsh
@@ -7,4 +7,3 @@
   fi
   antigen-bundle --loc=lib
 }
-

--- a/src/lib/use-prezto.zsh
+++ b/src/lib/use-prezto.zsh
@@ -1,4 +1,3 @@
 -antigen-use-prezto () {
   antigen-bundle "$ANTIGEN_PREZTO_REPO_URL"
 }
-

--- a/src/lib/zcache.zsh
+++ b/src/lib/zcache.zsh
@@ -65,6 +65,7 @@ _ZCACHE_BUNDLE=${_ZCACHE_BUNDLE:-false}
 -zcache-generate-cache () {
   local -aU _fpath _PATH
   local bundle _payload _sources
+  local line themes
 
   for bundle in $_ANTIGEN_BUNDLE_RECORD; do
     # Extract bundle metadata to pass them to -antigen-parse-bundle function.
@@ -115,6 +116,7 @@ _ZCACHE_BUNDLE=${_ZCACHE_BUNDLE:-false}
 #-- ANTIGEN {{ANTIGEN_VERSION}}
 $(functions -- _antigen)
 antigen () {
+  local MATCH MBEGIN MEND
   [[ \"\$ZSH_EVAL_CONTEXT\" =~ \"toplevel:*\" || \"\$ZSH_EVAL_CONTEXT\" =~ \"cmdarg:*\" ]] && source \""$_ANTIGEN_INSTALL_DIR/antigen.zsh"\" && eval antigen \$@;
   return 0;
 }

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -1,3 +1,6 @@
+# Display all globally defined variables from functions
+setopt localoptions warncreateglobal
+
 # zshrc file written for antigen's tests. Might not be a good one for daily use.
 # See cram's documentation for some of the variables used below.
 export ADOTDIR=$(mktemp -du "/tmp/dot-antigen-tmp-XXXXX")


### PR DESCRIPTION
- Use `setopt localoptions warncreateglobal` in tests