### PR TITLE
Don't require confirmation when removing lock

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1555,7 +1555,7 @@ antigen-ext () {
     # One time hook
     antigen-remove-hook antigen-apply-lock
     unset _ANTIGEN_LOCK_PROCESS
-    rm $ANTIGEN_LOCK &> /dev/null
+    rm -f $ANTIGEN_LOCK &> /dev/null
     antigen-apply "$@"
   }
   antigen-add-hook antigen-apply antigen-apply-lock replace

--- a/src/ext/lock.zsh
+++ b/src/ext/lock.zsh
@@ -33,7 +33,7 @@
     # One time hook
     antigen-remove-hook antigen-apply-lock
     unset _ANTIGEN_LOCK_PROCESS
-    rm $ANTIGEN_LOCK &> /dev/null
+    rm -f $ANTIGEN_LOCK &> /dev/null
     antigen-apply "$@"
   }
   antigen-add-hook antigen-apply antigen-apply-lock replace


### PR DESCRIPTION
When `rm` is aliased to `rm -i` before loading antigen (v2.1.0),
`antigen apply` tries to remove lock file but `rm` is waiting for user to confirm without prompt.

```shell
% rm -rf ~/.antigen/ $HOME/antigen/
% git clone https://github.com/zsh-users/antigen.git -b v2.1.0 $HOME/antigen
% cat > ~/.zshrc
alias rm="rm -i"

source $HOME/antigen/antigen.zsh
antigen bundle zsh-users/zsh-syntax-highlighting
antigen apply
<Ctrl-D>
% exec zsh -l 
Installing zsh-users/zsh-syntax-highlighting... Done. Took 1s.
```

Another terminal:

```console
% ps -f fw --user test
UID        PID  PPID  C STIME TTY      STAT   TIME CMD
test      3246  3240  0 02:45 ?        S      0:00 sshd: test@pts/0
test      3247  3246  0 02:45 pts/0    Ss     0:00  \_ zsh -l
test      3448  3247  0 02:54 pts/0    S+     0:00      \_ rm -i /home/test/.antigen/.lock
```
