### PR TITLE
Fix parallel extension running multiple clone instances

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1697,10 +1697,8 @@ antigen-ext-init () {
       if [[ ! -d ${bundle[dir]} && $repositories[(I)${bundle[url]}] == 0 ]]; then
         WARN "Install in parallel ${bundle[name]}." PARALLEL
         echo "Installing ${bundle[name]}!..."
-        # TODO what happens if we request multiple bundles on different branches
-        # on the same repository/library:
-        #     antigen bundle example/bundle1@develop
-        #     antigen bundle example/bundle2 (default master)
+        # $bundle[url]'s format is "url|branch" as to create "$ANTIGEN_BUNDLES/bundle/name-branch",
+        # this way you may require multiple branches from the same repository.
         -antigen-ensure-repo "${bundle[url]}" > /dev/null &!
         pids+=($!)
       else

--- a/src/ext/parallel.zsh
+++ b/src/ext/parallel.zsh
@@ -18,16 +18,25 @@
     WARN "Gonna install in parallel ${#_PARALLEL_BUNDLE} bundles." PARALLEL
     # Do ensure-repo in parallel
     WARN "${_PARALLEL_BUNDLE}" PARALLEL
+    typeset -Ua repositories # Used to keep track of cloned repositories to avoid
+                             # trying to clone it multiple times.
     for args in ${_PARALLEL_BUNDLE}; do
       typeset -A bundle; -antigen-parse-args 'bundle' ${=args}
-      if [[ ! -d ${bundle[dir]} ]]; then
+
+      if [[ ! -d ${bundle[dir]} && $repositories[(I)${bundle[url]}] == 0 ]]; then
         WARN "Install in parallel ${bundle[name]}." PARALLEL
         echo "Installing ${bundle[name]}!..."
+        # TODO what happens if we request multiple bundles on different branches
+        # on the same repository/library:
+        #     antigen bundle example/bundle1@develop
+        #     antigen bundle example/bundle2 (default master)
         -antigen-ensure-repo "${bundle[url]}" > /dev/null &!
         pids+=($!)
       else
         WARN "Bundle ${bundle[name]} already cloned locally." PARALLEL
       fi
+      
+      repositories+=(${bundle[url]})
     done
 
     # Wait for all background processes to end

--- a/src/ext/parallel.zsh
+++ b/src/ext/parallel.zsh
@@ -26,10 +26,8 @@
       if [[ ! -d ${bundle[dir]} && $repositories[(I)${bundle[url]}] == 0 ]]; then
         WARN "Install in parallel ${bundle[name]}." PARALLEL
         echo "Installing ${bundle[name]}!..."
-        # TODO what happens if we request multiple bundles on different branches
-        # on the same repository/library:
-        #     antigen bundle example/bundle1@develop
-        #     antigen bundle example/bundle2 (default master)
+        # $bundle[url]'s format is "url|branch" as to create "$ANTIGEN_BUNDLES/bundle/name-branch",
+        # this way you may require multiple branches from the same repository.
         -antigen-ensure-repo "${bundle[url]}" > /dev/null &!
         pids+=($!)
       else


### PR DESCRIPTION
- Antigen parallel extension launched multiple git-clone instances for the same repository
- It failed to determine if a repository was being cloned on the same batch
- It may skip some instances due to race conditions with file system (checking against directory existence)

Fixes #548


TODO

- [x] Review 'Signal 18 (CONT) caught by ps (procps-ng version 3.3.9).' error message (see [this line](https://github.com/desyncr/antigen/blob/f74cc75d2079219b03afcb9679fcc9774521643f/src/ext/parallel.zsh#L45))
- [x] Review [this](https://github.com/desyncr/antigen/blob/f74cc75d2079219b03afcb9679fcc9774521643f/src/ext/parallel.zsh#L29) TODO