### PR TITLE
Fix glob to build logging library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,10 @@ GLOB       += ${SRC}/boot.zsh
 EXTENSIONS += ${SRC}/ext/cache.zsh
 endif
 
-GLOB  += ${SRC}/antigen.zsh $(sort $(wildcard ${PWD}/src/helpers/*.zsh)) \
-        ${SRC}/lib/*.zsh $(sort $(wildcard ${PWD}/src/commands/*.zsh)) ${EXTENSIONS}
+LIB     = $(filter-out ${SRC}/lib/log.zsh,$(sort $(wildcard ${PWD}/src/lib/*.zsh)))
+HELPERS = $(sort $(wildcard ${PWD}/src/helpers/*.zsh)) 
+COMMANDS= $(sort $(wildcard ${PWD}/src/commands/*.zsh))
+GLOB   += ${SRC}/antigen.zsh ${HELPERS} ${LIB} ${COMMANDS} ${EXTENSIONS}
 
 ifeq (${WITH_COMPLETION}, yes)
 GLOB  += ${SRC}/_antigen
@@ -102,8 +104,8 @@ build:
 	@echo "${VERSION}" > ${VERSION_FILE}
 	@$(call ised,"s/{{ANTIGEN_VERSION}}/$$(cat ${VERSION_FILE})/",${TARGET})
 ifeq (${DEBUG}, no)
-	@$(call isede,"s/(WARN|LOG|ERR|TRA) .*& //",${TARGET})
-	@$(call isede,"/(WARN|LOG|ERR|TRA) .*/d",${TARGET})
+	@$(call isede,"s/ (WARN|LOG|ERR|TRACE) .*&//",${TARGET})
+	@$(call isede,"/ (WARN|LOG|ERR|TRACE) .*/d",${TARGET})
 endif
 	@echo Done.
 	@ls -sh ${TARGET}

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@
 WITH_LOCK=yes
 WITH_DEFER=yes
 WITH_CACHE=yes
+WITH_DEBUG=yes
 WITH_PARALLEL=yes
 WITH_EXTENSIONS=yes
 WITH_COMPLETION=yes
-DEBUG=yes
 ######################################################################
 SHELL     ?= sh
 PREFIX    ?= /usr/local
@@ -29,10 +29,10 @@ CONTAINER_IMAGE ?= desyncr/zsh-docker-
 
 TARGET     ?= ${BIN}/antigen.zsh
 SRC        ?= ${SRC}
-DEBUG      ?= yes
 EXTENSIONS ?= 
 GLOB       ?= 
 
+WITH_DEBUG      ?= yes
 WITH_EXTENSIONS ?= yes
 WITH_DEFER      ?= yes
 WITH_LOCK       ?= yes
@@ -66,7 +66,7 @@ ifeq (${WITH_COMPLETION}, yes)
 GLOB  += ${SRC}/_antigen
 endif
 # If debug is enabled then load debug functions
-ifeq (${DEBUG}, yes)
+ifeq (${WITH_DEBUG}, yes)
 GLOB  += ${SRC}/lib/log.zsh
 endif
 
@@ -103,7 +103,7 @@ build:
 	@echo "-antigen-env-setup" >> ${TARGET}
 	@echo "${VERSION}" > ${VERSION_FILE}
 	@$(call ised,"s/{{ANTIGEN_VERSION}}/$$(cat ${VERSION_FILE})/",${TARGET})
-ifeq (${DEBUG}, no)
+ifeq (${WITH_DEBUG}, no)
 	@$(call isede,"s/ (WARN|LOG|ERR|TRACE) .*&//",${TARGET})
 	@$(call isede,"/ (WARN|LOG|ERR|TRACE) .*/d",${TARGET})
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -45,8 +45,10 @@ GLOB       += ${SRC}/boot.zsh
 EXTENSIONS += ${SRC}/ext/cache.zsh
 endif
 
-GLOB  += ${SRC}/antigen.zsh $(sort $(wildcard ${PWD}/src/helpers/*.zsh)) \
-        ${SRC}/lib/*.zsh $(sort $(wildcard ${PWD}/src/commands/*.zsh)) ${EXTENSIONS}
+LIB     = $(filter-out ${SRC}/lib/log.zsh,$(sort $(wildcard ${PWD}/src/lib/*.zsh)))
+HELPERS = $(sort $(wildcard ${PWD}/src/helpers/*.zsh)) 
+COMMANDS= $(sort $(wildcard ${PWD}/src/commands/*.zsh))
+GLOB   += ${SRC}/antigen.zsh ${HELPERS} ${LIB} ${COMMANDS} ${EXTENSIONS}
 
 ifeq (${WITH_COMPLETION}, yes)
 GLOB  += ${SRC}/_antigen
@@ -90,8 +92,8 @@ build:
 	@echo "${VERSION}" > ${VERSION_FILE}
 	@$(call ised,"s/{{ANTIGEN_VERSION}}/$$(cat ${VERSION_FILE})/",${TARGET})
 ifeq (${DEBUG}, no)
-	@$(call isede,"s/(WARN|LOG|ERR|TRA) .*& //",${TARGET})
-	@$(call isede,"/(WARN|LOG|ERR|TRA) .*/d",${TARGET})
+	@$(call isede,"s/ (WARN|LOG|ERR|TRACE) .*&//",${TARGET})
+	@$(call isede,"/ (WARN|LOG|ERR|TRACE) .*/d",${TARGET})
 endif
 	@echo Done.
 	@ls -sh ${TARGET}

--- a/Makefile.in
+++ b/Makefile.in
@@ -17,10 +17,10 @@ CONTAINER_IMAGE ?= desyncr/zsh-docker-
 
 TARGET     ?= ${BIN}/antigen.zsh
 SRC        ?= ${SRC}
-DEBUG      ?= yes
 EXTENSIONS ?= 
 GLOB       ?= 
 
+WITH_DEBUG      ?= yes
 WITH_EXTENSIONS ?= yes
 WITH_DEFER      ?= yes
 WITH_LOCK       ?= yes
@@ -54,7 +54,7 @@ ifeq (${WITH_COMPLETION}, yes)
 GLOB  += ${SRC}/_antigen
 endif
 # If debug is enabled then load debug functions
-ifeq (${DEBUG}, yes)
+ifeq (${WITH_DEBUG}, yes)
 GLOB  += ${SRC}/lib/log.zsh
 endif
 
@@ -91,7 +91,7 @@ build:
 	@echo "-antigen-env-setup" >> ${TARGET}
 	@echo "${VERSION}" > ${VERSION_FILE}
 	@$(call ised,"s/{{ANTIGEN_VERSION}}/$$(cat ${VERSION_FILE})/",${TARGET})
-ifeq (${DEBUG}, no)
+ifeq (${WITH_DEBUG}, no)
 	@$(call isede,"s/ (WARN|LOG|ERR|TRACE) .*&//",${TARGET})
 	@$(call isede,"/ (WARN|LOG|ERR|TRACE) .*/d",${TARGET})
 endif

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -554,27 +554,6 @@ antigen () {
     fi
   done
 }
-zmodload zsh/datetime
-ANTIGEN_DEBUG_LOG=${ANTIGEN_DEBUG_LOG:-${ADOTDIR:-$HOME/.antigen}/debug.log}
-LOG () {
-  local PREFIX="[LOG][${EPOCHREALTIME}]"
-  echo "${PREFIX} ${funcfiletrace[1]}\n${PREFIX} $@" >> $ANTIGEN_DEBUG_LOG
-}
-
-ERR () {
-  local PREFIX="[ERR][${EPOCHREALTIME}]"
-  echo "${PREFIX} ${funcfiletrace[1]}\n${PREFIX} $@" >> $ANTIGEN_DEBUG_LOG
-}
-
-WARN () {
-  local PREFIX="[WRN][${EPOCHREALTIME}]"
-  echo "${PREFIX} ${funcfiletrace[1]}\n${PREFIX} $@" >> $ANTIGEN_DEBUG_LOG
-}
-
-TRACE () {
-  local PREFIX="[TRA][${EPOCHREALTIME}]"
-  echo "${PREFIX} ${funcfiletrace[1]}\n${PREFIX} $@\n${PREFIX} ${(j:\n:)funcstack}" >> $ANTIGEN_DEBUG_LOG
-}
 # Usage:
 #   -antigen-parse-args output_assoc_arr <args...>
 -antigen-parse-args () {

--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@ target=Makefile
 arguments="$@"
 typeset -A opts;
 opts=(
-debug           yes
+with-debug      yes
 with-extensions yes
 with-lock 	    yes
 with-parallel	  yes
@@ -12,6 +12,39 @@ with-cache 	    yes
 with-defer 	    yes
 with-completion yes
 )
+
+if [[ $1 == "--help" || $1 == "-h" ]]; then
+cat >&1 <<EOH
+Usage:
+    ./configure --with-option[=[yes|no]] --[enable|disable]-option
+
+Available options:
+
+    - debug      - Enable/disable debug library
+    - extensions - Enable/disable lock, parallel, cache and defer options
+    - lock       - Enable/disable lock
+    - parallel   - Enable/disable parallel
+    - cache      - Enable/disable cache
+    - defer      - Enable/disable defer
+    - completion - Enable/disable completion
+
+All options are enabled by default.
+
+Example:
+
+    # Disable lock, parallel, cache and defer
+    ./configure --disable-extensions
+
+    # Disable completion
+    ./configure --disable-completion
+    
+    # Enable debug
+    ./configure --with-debug
+
+EOH
+  exit 0 
+fi
+
 
 while [[ $# -gt 0 ]]; do
 	argkey="${1%\=*}"


### PR DESCRIPTION
Logging library was always build with either `--enable-debug` or `--disable-debug`. Fixed globbing to properly load helpers functions depending on build mode.