### PR TITLE
Detect resource file overrides

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -10,7 +10,13 @@ zmodload zsh/parameter
 
 if [[ $ANTIGEN_CACHE != false ]]; then
   ANTIGEN_CACHE="${ANTIGEN_CACHE:-${ADOTDIR:-$HOME/.antigen}/init.zsh}"
-  ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+
+  # if zsh >= 5.3, we can test to see if ANTIGENT_RSRC is set without setting it
+  if test "$( zsh --version | awk '{print $2}' | awk -F'.' ' ( $1 > 5 || ( $1 == 5 && $2 >= 3 ) ) ' )"; then
+    [[ -v ANTIGEN_RSRC ]] || ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+  else
+    ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+  fi
 
   if [[ $ANTIGEN_AUTO_CONFIG != false && -f $ANTIGEN_RSRC ]]; then
     ANTIGEN_CHECK_FILES=$(cat $ANTIGEN_RSRC 2> /dev/null)

--- a/src/boot.zsh
+++ b/src/boot.zsh
@@ -2,7 +2,13 @@ zmodload zsh/parameter
 
 if [[ $ANTIGEN_CACHE != false ]]; then
   ANTIGEN_CACHE="${ANTIGEN_CACHE:-${ADOTDIR:-$HOME/.antigen}/init.zsh}"
-  ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+
+  # if zsh >= 5.3, we can test to see if ANTIGENT_RSRC is set without setting it
+  if test "$( zsh --version | awk '{print $2}' | awk -F'.' ' ( $1 > 5 || ( $1 == 5 && $2 >= 3 ) ) ' )"; then
+    [[ -v ANTIGEN_RSRC ]] || ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+  else
+    ANTIGEN_RSRC="${ADOTDIR:-$HOME/.antigen}/.resources"
+  fi
 
   if [[ $ANTIGEN_AUTO_CONFIG != false && -f $ANTIGEN_RSRC ]]; then
     ANTIGEN_CHECK_FILES=$(cat $ANTIGEN_RSRC 2> /dev/null)


### PR DESCRIPTION
Depends on zsh >= 5.3, where "-v" was introduced. As this was relatively
recent (2016-12-12) there is a fallback mechanism which reverts to the
old functionality.

Closes zsh-users/antigen#598