### PR TITLE
Avoid adding repeated entries to antigen rsrc

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1864,7 +1864,7 @@ EOC
     # There always should be 5 steps from original source as the correct way is to use
     # `antigen` wrapper not `antigen-apply` directly and it's called by an extension.
     LOG "TRACE: ${funcfiletrace}"
-    if [[ $ANTIGEN_AUTO_CONFIG == true ]]; then
+    if [[ $ANTIGEN_AUTO_CONFIG == true && $#ANTIGEN_CHECK_FILES -eq 0 ]]; then
       ANTIGEN_CHECK_FILES+=(~/.zshrc)
       if [[ $#funcfiletrace -ge 6 ]]; then
         ANTIGEN_CHECK_FILES+=("${${funcfiletrace[6]%:*}##* }")

--- a/src/ext/cache.zsh
+++ b/src/ext/cache.zsh
@@ -116,7 +116,7 @@ EOC
     # There always should be 5 steps from original source as the correct way is to use
     # `antigen` wrapper not `antigen-apply` directly and it's called by an extension.
     LOG "TRACE: ${funcfiletrace}"
-    if [[ $ANTIGEN_AUTO_CONFIG == true ]]; then
+    if [[ $ANTIGEN_AUTO_CONFIG == true && $#ANTIGEN_CHECK_FILES -eq 0 ]]; then
       ANTIGEN_CHECK_FILES+=(~/.zshrc)
       if [[ $#funcfiletrace -ge 6 ]]; then
         ANTIGEN_CHECK_FILES+=("${${funcfiletrace[6]%:*}##* }")


### PR DESCRIPTION
When resetting cache it will append content to ANTIGEN_CHECK_FILES variable.