### PR TITLE
Ignore insecure files and directories in compinit

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -476,7 +476,7 @@ antigen () {
   if -antigen-interactive-mode; then
     TRACE "Gonna create compdump file @ env-setup" COMPDUMP
     autoload -Uz compinit
-    compinit -d "$ANTIGEN_COMPDUMP"
+    compinit -i -d "$ANTIGEN_COMPDUMP"
     compdef _antigen antigen
   else
     (( $+functions[antigen-ext-init] )) && antigen-ext-init
@@ -790,7 +790,7 @@ antigen-apply () {
   # the one that actually initializes completions.
   TRACE "Gonna create compdump file @ apply" COMPDUMP
   autoload -Uz compinit
-  compinit -d "$ANTIGEN_COMPDUMP"
+  compinit -i -d "$ANTIGEN_COMPDUMP"
 
   # Apply all `compinit`s that have been deferred.
   local cdef
@@ -1820,7 +1820,7 @@ antigen () {
 typeset -gaU fpath path
 fpath+=(${_fpath[@]}) path+=(${_PATH[@]})
 _antigen_compinit () {
-  autoload -Uz compinit; compinit -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
+  autoload -Uz compinit; compinit -i -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
   add-zsh-hook -D precmd _antigen_compinit
 }
 autoload -Uz add-zsh-hook; add-zsh-hook precmd _antigen_compinit

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -453,6 +453,7 @@ antigen () {
   fi
 
   -antigen-set-default ANTIGEN_COMPDUMP "${ADOTDIR:-$HOME}/.zcompdump"
+  -antigen-set-default ANTIGEN_COMPINIT "compinit"
   -antigen-set-default ANTIGEN_LOG /dev/null
 
   # CLONE_OPTS uses ${=CLONE_OPTS} expansion so don't use spaces
@@ -476,7 +477,7 @@ antigen () {
   if -antigen-interactive-mode; then
     TRACE "Gonna create compdump file @ env-setup" COMPDUMP
     autoload -Uz compinit
-    compinit -i -d "$ANTIGEN_COMPDUMP"
+    "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"
     compdef _antigen antigen
   else
     (( $+functions[antigen-ext-init] )) && antigen-ext-init
@@ -790,7 +791,7 @@ antigen-apply () {
   # the one that actually initializes completions.
   TRACE "Gonna create compdump file @ apply" COMPDUMP
   autoload -Uz compinit
-  compinit -i -d "$ANTIGEN_COMPDUMP"
+  "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"
 
   # Apply all `compinit`s that have been deferred.
   local cdef
@@ -1820,7 +1821,7 @@ antigen () {
 typeset -gaU fpath path
 fpath+=(${_fpath[@]}) path+=(${_PATH[@]})
 _antigen_compinit () {
-  autoload -Uz compinit; compinit -i -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
+  autoload -Uz compinit; "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
   add-zsh-hook -D precmd _antigen_compinit
 }
 autoload -Uz add-zsh-hook; add-zsh-hook precmd _antigen_compinit

--- a/src/commands/apply.zsh
+++ b/src/commands/apply.zsh
@@ -6,7 +6,7 @@ antigen-apply () {
   # the one that actually initializes completions.
   TRACE "Gonna create compdump file @ apply" COMPDUMP
   autoload -Uz compinit
-  compinit -i -d "$ANTIGEN_COMPDUMP"
+  "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"
 
   # Apply all `compinit`s that have been deferred.
   local cdef

--- a/src/commands/apply.zsh
+++ b/src/commands/apply.zsh
@@ -6,7 +6,7 @@ antigen-apply () {
   # the one that actually initializes completions.
   TRACE "Gonna create compdump file @ apply" COMPDUMP
   autoload -Uz compinit
-  compinit -d "$ANTIGEN_COMPDUMP"
+  compinit -i -d "$ANTIGEN_COMPDUMP"
 
   # Apply all `compinit`s that have been deferred.
   local cdef

--- a/src/ext/cache.zsh
+++ b/src/ext/cache.zsh
@@ -52,7 +52,7 @@ antigen () {
 typeset -gaU fpath path
 fpath+=(${_fpath[@]}) path+=(${_PATH[@]})
 _antigen_compinit () {
-  autoload -Uz compinit; compinit -i -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
+  autoload -Uz compinit; "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
   add-zsh-hook -D precmd _antigen_compinit
 }
 autoload -Uz add-zsh-hook; add-zsh-hook precmd _antigen_compinit

--- a/src/ext/cache.zsh
+++ b/src/ext/cache.zsh
@@ -52,7 +52,7 @@ antigen () {
 typeset -gaU fpath path
 fpath+=(${_fpath[@]}) path+=(${_PATH[@]})
 _antigen_compinit () {
-  autoload -Uz compinit; compinit -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
+  autoload -Uz compinit; compinit -i -d "$ANTIGEN_COMPDUMP"; compdef _antigen antigen
   add-zsh-hook -D precmd _antigen_compinit
 }
 autoload -Uz add-zsh-hook; add-zsh-hook precmd _antigen_compinit

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -31,6 +31,7 @@
   fi
 
   -antigen-set-default ANTIGEN_COMPDUMP "${ADOTDIR:-$HOME}/.zcompdump"
+  -antigen-set-default ANTIGEN_COMPINIT "compinit"
   -antigen-set-default ANTIGEN_LOG /dev/null
 
   # CLONE_OPTS uses ${=CLONE_OPTS} expansion so don't use spaces
@@ -54,7 +55,7 @@
   if -antigen-interactive-mode; then
     TRACE "Gonna create compdump file @ env-setup" COMPDUMP
     autoload -Uz compinit
-    compinit -i -d "$ANTIGEN_COMPDUMP"
+    "$ANTIGEN_COMPINIT" -d "$ANTIGEN_COMPDUMP"
     compdef _antigen antigen
   else
     (( $+functions[antigen-ext-init] )) && antigen-ext-init

--- a/src/lib/env-setup.zsh
+++ b/src/lib/env-setup.zsh
@@ -54,7 +54,7 @@
   if -antigen-interactive-mode; then
     TRACE "Gonna create compdump file @ env-setup" COMPDUMP
     autoload -Uz compinit
-    compinit -d "$ANTIGEN_COMPDUMP"
+    compinit -i -d "$ANTIGEN_COMPDUMP"
     compdef _antigen antigen
   else
     (( $+functions[antigen-ext-init] )) && antigen-ext-init


### PR DESCRIPTION
This might be a bit controversial PR, and I'm definitely open for suggestions on how to do things differently.

Let me explain the problem that I'm trying to solve. I have all my dotfiles (including antigen) in my home dir, all of them are owned by my regular user. Sometimes I know that I need to execute a few privileged operations, so instead of prepending each command with `sudo` I change to root with `$ sudo -s` and then execute the commands without any prefix.

I like using `$ sudo -s`, because it preserves my user environment, $HOME directory, my prompt, antigen configuration, everything stays the same. However, when I enter `$ sudo -s`, I'm welcomed with the following message:

```
❯ sudo -s
zsh compinit: insecure directories and files, run compaudit for list.
Ignore insecure directories and files and continue [y] or abort compinit [n]?
```

This happens because of the [following](http://zsh.sourceforge.net/Doc/Release/Completion-System.html):

> For security reasons compinit also checks if the completion system would use files not owned by root or by the current user, or files in directories that are world- or group-writable or that are not owned by root or by the current user.

Basically, compinit complains because current user is `root`, and dotfiles are owned by a different user.

I can't "fix" the permissions, I want my dotfiles to be owned by my own user, so I see this annoying warning every time.

Adding `-i` is an easy win, this flag makes compinit silently ignore all insecure files and directories.

What do you think about it, can we add it?