### PR TITLE
Show help message on missing arguments

### DIFF
--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -68,7 +68,7 @@ compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
 antigen () {
   local cmd="$1"
   if [[ -z "$cmd" ]]; then
-    echo 'Antigen: Please give a command to run.' >&2
+    antigen-help >&2
     return 1
   fi
   shift

--- a/bin/antigen.zsh
+++ b/bin/antigen.zsh
@@ -1402,7 +1402,7 @@ antigen-use () {
 antigen-version () {
   local extensions
 
-  printf "Antigen %s (%s)\nRevision date: %s\n" "develop" "f3b7bc4" "2018-01-14 13:05:10 -0300"
+  printf "Antigen %s (%s)\nRevision date: %s\n" "develop" "9312823" "2018-01-15 14:20:20 -0300"
 
   # Show extension information if any is available
   if (( $+functions[antigen-ext] )); then

--- a/src/antigen.zsh
+++ b/src/antigen.zsh
@@ -20,7 +20,7 @@ compdef () { __deferred_compdefs=($__deferred_compdefs "$*") }
 antigen () {
   local cmd="$1"
   if [[ -z "$cmd" ]]; then
-    echo 'Antigen: Please give a command to run.' >&2
+    antigen-help >&2
     return 1
   fi
   shift

--- a/tests/antigen-wrapper.t
+++ b/tests/antigen-wrapper.t
@@ -19,3 +19,16 @@ Call with an alias
   $ alias a=antigen
   $ a dummy
   me dummy
+
+Call without arguments should exit with error.
+
+  $ antigen 2>/dev/null
+  [1]
+
+Call without arguments should display help message.
+
+  $ antigen 2>&1 | head -n 4
+  Antigen .* (re)
+  Revision .* (re)
+  
+  Antigen is a .* (re)


### PR DESCRIPTION
```
 > antigen
Antigen develop (f3b7bc4)
Revision date: 2018-01-14 13:05:10 -0300

Antigen is a plugin management system for zsh. It makes it easy to grab awesome
shell scripts and utilities, put up on Github.

Usage: antigen <command> [args]

Commands:
  apply        Must be called in the zshrc after all calls to 'antigen bundle'.
  bundle       Install and load a plugin.
  cache-gen    Generate Antigen's cache with currently loaded bundles.
  cleanup      Remove clones of repos not used by any loaded plugins.
  init         Use caching to quickly load bundles.
  list         List currently loaded plugins.
  purge        Remove a bundle from the filesystem.
  reset        Clean the generated cache.
  restore      Restore plugin state from a snapshot file.
  revert       Revert plugins to their state prior to the last time 'antigen
               update' was run.
  selfupdate   Update antigen.
  snapshot     Create a snapshot of all active plugin repos and save it to a
               snapshot file.
  update       Update plugins.
  use          Load a supported zsh pre-packaged framework.

For further details and complete documentation, visit the project's page at
'http://antigen.sharats.me'.
```