### PR TITLE
fix: add space to configure flags

### DIFF
--- a/tools/builder
+++ b/tools/builder
@@ -69,7 +69,7 @@ function builder/compile () {
   fi
 
   # Configure bindir for this branch
-  ./configure --bindir="$target/$version" --prefix="$target/$version"--without-tcsetpgrp
+  ./configure --bindir="$target/$version" --prefix="$target/$version" --without-tcsetpgrp
 
   # Make
   make -j5


### PR DESCRIPTION
Caused compilation to script to break

<img width="746" alt="Screenshot 2022-08-01 at 12 24 55 AM" src="https://user-images.githubusercontent.com/10052309/182077968-55cf8221-8f57-4b73-9906-14864e4b89e9.png">
